### PR TITLE
Fix so that the logger only returns one global logger, allowing logging

### DIFF
--- a/icloudpd/logger.py
+++ b/icloudpd/logger.py
@@ -32,21 +32,27 @@ class IPDLogger(logging.Logger):
             self.tqdm.write(message)
 
 
+logger = None
 def setup_logger(loglevel=DEBUG):
     """Set up logger and add stdout handler"""
-    logging.setLoggerClass(IPDLogger)
-    logger = logging.getLogger("icloudpd")
-    logger.setLevel(loglevel)
-    has_stdout_handler = False
-    for handler in logger.handlers:
-        if handler.name == "stdoutLogger":
-            has_stdout_handler = True
-    if not has_stdout_handler:
-        formatter = logging.Formatter(
-            fmt="%(asctime)s %(levelname)-8s %(message)s",
-            datefmt="%Y-%m-%d %H:%M:%S")
-        stdout_handler = logging.StreamHandler(stream=sys.stdout)
-        stdout_handler.setFormatter(formatter)
-        stdout_handler.name = "stdoutLogger"
-        logger.addHandler(stdout_handler)
+    global logger
+    if logger:
+        return logger
+    else:
+        logging.setLoggerClass(IPDLogger)
+        logger = logging.getLogger("icloudpd")
+        logger.setLevel(loglevel)
+        has_stdout_handler = False
+        for handler in logger.handlers:
+            if handler.name == "stdoutLogger":
+                has_stdout_handler = True
+        if not has_stdout_handler:
+            formatter = logging.Formatter(
+                fmt="%(asctime)s %(levelname)-8s %(message)s",
+                datefmt="%Y-%m-%d %H:%M:%S")
+            stdout_handler = logging.StreamHandler(stream=sys.stdout)
+            stdout_handler.setFormatter(formatter)
+            stdout_handler.name = "stdoutLogger"
+            logger.addHandler(stdout_handler)
+
     return logger


### PR DESCRIPTION
settings to be used globally, and eliminating the overlogging when a log-level is specified.