### PR TITLE
set default threads to 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,8 +118,7 @@ pip install icloudpd
                                         prints log messages on separate lines
                                         (Progress bar is disabled by default if
                                         there is no tty attached)
-        --threads-num INTEGER RANGE     Number of cpu threads(default: cpu count *
-                                        5)
+        --threads-num INTEGER RANGE     Number of cpu threads (default: 1)
         --version                       Show the version and exit.
         -h, --help                      Show this message and exit.
 

--- a/icloudpd/base.py
+++ b/icloudpd/base.py
@@ -10,7 +10,6 @@ import itertools
 import subprocess
 import json
 import threading
-import multiprocessing
 import click
 
 from tqdm import tqdm
@@ -195,9 +194,9 @@ CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
               )
 @click.option(
     "--threads-num",
-    help="Number of cpu threads(default: cpu count * 5)",
+    help="Number of cpu threads (default: 1)",
     type=click.IntRange(1),
-    default=multiprocessing.cpu_count() * 5,
+    default=1,
 )
 @click.version_option()
 # pylint: disable-msg=too-many-arguments,too-many-statements


### PR DESCRIPTION
What: sets default `--threads-num` parameter to 1
Why: multi-threaded download causing issues when duplicate files exist in iCloud or on disk. Changing default will help reduce a number of issues. #155
Note: Discussion about deprecating multi-threaded downloading is separate from this fix