### PR TITLE
Delete first and size check

### DIFF
--- a/icloudpd/autodelete.py
+++ b/icloudpd/autodelete.py
@@ -17,15 +17,20 @@ def autodelete_photos(icloud, folder_structure, directory):
 
     recently_deleted = icloud.photos.albums["Recently Deleted"]
 
-    for media in recently_deleted:
-        created_date = media.created
-        date_path = folder_structure.format(created_date)
-        download_dir = os.path.join(directory, date_path)
+    all_photos_id = []
+    for photo in icloud.photos.all:
+        all_photos_id.append(photo.id)
 
-        for size in [None, "original", "medium", "thumb"]:
-            path = os.path.normpath(
-                local_download_path(
-                    media, size, download_dir))
-            if os.path.exists(path):
-                logger.info("Deleting %s!", path)
-                os.remove(path)
+    for media in recently_deleted:
+        if not (media.id in all_photos_id):
+            created_date = media.created
+            date_path = folder_structure.format(created_date)
+            download_dir = os.path.join(directory, date_path)
+
+            for size in [None, "original", "medium", "thumb"]:
+                path = os.path.normpath(
+                    local_download_path(
+                        media, size, download_dir))
+                if os.path.exists(path):
+                    logger.info("Deleting %s!", path)
+                    os.remove(path)


### PR DESCRIPTION
The code should do the delete task first, then do the download task, and add the size check before deleting.

**Why:**
When you took a photo with your iPhone, then copied the photo for some reason, and then deleted the copied photo. 
At this time, the deleted photo has the same file name as the original photo. If the download task is performed before the deletion task, the original photo will be deleted by subsequent deletion tasks.

**TODO**
Fix tests run....