### PR TITLE
Fix log-level option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- fix: --log-level option [#194](https://github.com/icloud-photos-downloader/icloud_photos_downloader/pull/194)
 - feature: Folder structure can be set to 'none' instead of a date pattern,
 so all photos will be placed directly into the download directory.
 - fix: Empty directory structure being created #185

--- a/icloudpd/logger.py
+++ b/icloudpd/logger.py
@@ -2,7 +2,7 @@
 
 import sys
 import logging
-from logging import DEBUG, INFO
+from logging import INFO
 
 
 class IPDLogger(logging.Logger):
@@ -32,11 +32,10 @@ class IPDLogger(logging.Logger):
             self.tqdm.write(message)
 
 
-def setup_logger(loglevel=DEBUG):
+def setup_logger():
     """Set up logger and add stdout handler"""
     logging.setLoggerClass(IPDLogger)
     logger = logging.getLogger("icloudpd")
-    logger.setLevel(loglevel)
     has_stdout_handler = False
     for handler in logger.handlers:
         if handler.name == "stdoutLogger":


### PR DESCRIPTION
The log level is set on the logger instance in `icloudpd.base.main` based on the `--log-level` option, but subsequent calls to `setup_logger()` resets the level to `DEBUG`. As a result the `--log-level` option is effectively ignored.

Since the `--log-level` option defaults to `DEBUG` it's safe to remove `logger.setLevel()` from `setup_logger()` which allows the option to work as expected.