### PR TITLE
Introduce dependabot to keep things up2date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "pip" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3


### PR DESCRIPTION
We were talking about updating the libs we're using recently. I just learned about Dependabot which is a bot that runs inside of GitHub and does just that: checking if there's a new Version of a lib and if so it creates a pull request to update to that version, which also includes the changeling of that lib! See here: https://github.blog/2020-06-01-keep-all-your-packages-up-to-date-with-dependabot/

Sample pull request in my clone: https://github.com/menkej/icloud_photos_downloader/pull/2

I think that's really a cool thing. I tried it in my fork and it works just like I would have expected it. I did basically start with the default configuration which sounded save and didn't not start with automatic merging of minor versions right away. Not everything on the first date - get to know each other first! ;-) To not bombard us with pull requests I limited it to max 3 open requests and not a daily but weekly run...