### PR TITLE
force pip to fail when dependencies cannot be met

### DIFF
--- a/scripts/install_deps
+++ b/scripts/install_deps
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -euo pipefail
-pip3 install -r requirements.txt
-pip3 install -r requirements-test.txt
-pip3 install -r requirements-dev.txt
+python3 -m pip install --upgrade "pip>=20.2"
+pip3 install --use-feature=2020-resolver -r requirements.txt
+pip3 install --use-feature=2020-resolver -r requirements-test.txt
+pip3 install --use-feature=2020-resolver -r requirements-dev.txt


### PR DESCRIPTION
using new pip resolver that will be default in next pip version. that resolver fails pip when dependencies cannot be met. We need it for dependabot and manual upgrades. no change log updates as there is no customer facing changes