### PR TITLE
fix docker build on win

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-*.sh text eol=lf

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix: dev docker build on windows correctly manages crlf for scripts
+
 ## 1.7.1 (2020-11-10)
 
 - fix: --only-print-filenames option displays filenames (live photos) of files that have already been downloaded #200

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,11 +11,14 @@ RUN pip3 install --use-feature=2020-resolver -r requirements.txt
 
 FROM base as test
 
+RUN apt-get update && apt-get install -y dos2unix
 RUN mkdir Photos
 COPY requirements*.txt .
 COPY scripts/install_deps scripts/install_deps
+RUN dos2unix scripts/install_deps
 RUN scripts/install_deps
 COPY . .
+RUN dos2unix scripts/*
 ENV TZ="America/Los_Angeles"
 RUN scripts/test
 RUN scripts/lint

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ FROM base as test
 
 RUN apt-get update && apt-get install -y dos2unix
 RUN mkdir Photos
-COPY requirements*.txt .
+COPY requirements*.txt ./
 COPY scripts/install_deps scripts/install_deps
 RUN dos2unix scripts/install_deps
 RUN scripts/install_deps


### PR DESCRIPTION
Linux shell is sensitive to line ends in scripts. When scripts are executed inside dev docker build, they must match used image os (linux).

Git is smart to convert line ends for text files depending on the platform. Docker builds on macos or linux get correct line ends from the repo. When repo is on windows, git checks out scripts as crlf (==windows) and docker build copies them to the image blindly, causing shell execution error.

As a fix, we use dos2unix at the build step to ensure that scripts are always with unix line ends inside docker.