### PR TITLE
Short progress bar

### DIFF
--- a/icloudpd/base.py
+++ b/icloudpd/base.py
@@ -120,13 +120,12 @@ CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
     + "(Does not download or delete any files.)",
     is_flag=True,
 )
-@click.option(
-    "--folder-structure",
-    help="Folder structure (default: {:%Y/%m/%d}). "
-    "If set to 'none' all photos will just be placed into the download directory",
-    metavar="<folder_structure>",
-    default="{:%Y/%m/%d}",
-)
+@click.option("--folder-structure",
+              help="Folder structure (default: {:%Y/%m/%d}). "
+              "If set to 'none' all photos will just be placed into the download directory",
+              metavar="<folder_structure>",
+              default="{:%Y/%m/%d}",
+              )
 @click.option(
     "--set-exif-datetime",
     help="Write the DateTimeOriginal exif tag from file creation date, " +
@@ -187,12 +186,11 @@ CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
               "(Progress bar is disabled by default if there is no tty attached)",
               is_flag=True,
               )
-@click.option(
-    "--threads-num",
-    help="Number of cpu threads -- deprecated. To be removed in future version",
-    type=click.IntRange(1),
-    default=1,
-)
+@click.option("--threads-num",
+              help="Number of cpu threads -- deprecated. To be removed in future version",
+              type=click.IntRange(1),
+              default=1,
+              )
 @click.version_option()
 # pylint: disable-msg=too-many-arguments,too-many-statements
 # pylint: disable-msg=too-many-branches,too-many-locals
@@ -441,7 +439,7 @@ def main(
         # full path to the file to download
         download_path = local_download_path(
             photo, download_size, download_dir)
-        
+
         file_exists = os.path.isfile(download_path)
         if not file_exists and download_size == "original":
             # Deprecation - We used to download files like IMG_1234-original.jpg,
@@ -462,7 +460,7 @@ def main(
                     download_path.rsplit(".", 1)
                 )
                 # filepath below download_dir to shorten output
-                download_filename = download_path[len(directory)+1:]
+                download_filename = download_path[len(directory) + 1:]
                 logger.set_tqdm_description(
                     "%s deduplicated." % truncate_middle(download_filename, 60)
                 )
@@ -470,17 +468,18 @@ def main(
             if file_exists:
                 counter.increment()
                 # filepath below download_dir to shorten output
-                download_filename = download_path[len(directory)+1:]
+                download_filename = download_path[len(directory) + 1:]
                 logger.set_tqdm_description(
-                    "%s already exists." % truncate_middle(download_filename, 60)
-                )
-        else: # file does not exist
+                    "%s already exists." %
+                    truncate_middle(
+                        download_filename, 60))
+        else:  # file does not exist
             counter.reset()
             if only_print_filenames:
                 print(download_path)
             else:
                 # filepath below download_dir to shorten output
-                download_filename = download_path[len(directory)+1:]
+                download_filename = download_path[len(directory) + 1:]
 
                 truncated_path = truncate_middle(download_filename, 60)
                 logger.set_tqdm_description(
@@ -523,11 +522,11 @@ def main(
 
                 lp_file_exists = os.path.isfile(lp_download_path)
 
-                # todo: rework this
+                # for later: rework this
                 if only_print_filenames and not lp_file_exists:
                     print(lp_download_path)
                 else:
-                    if lp_file_exists: # live photo movie part is alreay there
+                    if lp_file_exists:  # live photo movie part is alreay there
                         lp_file_size = os.stat(lp_download_path).st_size
                         lp_photo_size = version["size"]
                         if lp_file_size != lp_photo_size:
@@ -535,7 +534,8 @@ def main(
                                 lp_download_path.rsplit(".", 1)
                             )
                             # filepath below download_dir to shorten output
-                            lp_download_filename = lp_download_path[len(directory)+1:]
+                            lp_download_filename = lp_download_path[len(
+                                directory) + 1:]
                             logger.set_tqdm_description(
                                 "%s deduplicated." %
                                 truncate_middle(
@@ -543,16 +543,20 @@ def main(
                             lp_file_exists = os.path.isfile(lp_download_path)
                         if lp_file_exists:
                             # filepath below download_dir to shorten output
-                            lp_download_filename = lp_download_path[len(directory)+1:]
+                            lp_download_filename = lp_download_path[len(
+                                directory) + 1:]
                             logger.set_tqdm_description(
                                 "%s already exists."
                                 % truncate_middle(lp_download_filename, 60)
                             )
-                    else: # live photo movie part is alreay there
+                    else:  # live photo movie part is alreay there
                         # filepath below download_dir to shorten output
-                        lp_download_filename = lp_download_path[len(directory)+1:]
+                        lp_download_filename = lp_download_path[len(
+                            directory) + 1:]
                         logger.set_tqdm_description(
-                            "Downloading %s" % truncate_middle(lp_download_filename, 60))
+                            "Downloading %s" %
+                            truncate_middle(
+                                lp_download_filename, 60))
                         download.download_media(
                             icloud, photo, lp_download_path, lp_size
                         )

--- a/icloudpd/base.py
+++ b/icloudpd/base.py
@@ -438,9 +438,10 @@ def main(
                 return
             download_size = "original"
 
+        # full path to the file to download
         download_path = local_download_path(
             photo, download_size, download_dir)
-
+        
         file_exists = os.path.isfile(download_path)
         if not file_exists and download_size == "original":
             # Deprecation - We used to download files like IMG_1234-original.jpg,
@@ -460,22 +461,28 @@ def main(
                 download_path = ("-%s." % photo_size).join(
                     download_path.rsplit(".", 1)
                 )
+                # filepath below download_dir to shorten output
+                download_filename = download_path[len(directory)+1:]
                 logger.set_tqdm_description(
-                    "%s deduplicated." % truncate_middle(download_path, 96)
+                    "%s deduplicated." % truncate_middle(download_filename, 60)
                 )
                 file_exists = os.path.isfile(download_path)
             if file_exists:
                 counter.increment()
+                # filepath below download_dir to shorten output
+                download_filename = download_path[len(directory)+1:]
                 logger.set_tqdm_description(
-                    "%s already exists." % truncate_middle(download_path, 96)
+                    "%s already exists." % truncate_middle(download_filename, 60)
                 )
-
-        if not file_exists:
+        else: # file does not exist
             counter.reset()
             if only_print_filenames:
                 print(download_path)
             else:
-                truncated_path = truncate_middle(download_path, 96)
+                # filepath below download_dir to shorten output
+                download_filename = download_path[len(directory)+1:]
+
+                truncated_path = truncate_middle(download_filename, 60)
                 logger.set_tqdm_description(
                     "Downloading %s" %
                     truncated_path)
@@ -516,30 +523,36 @@ def main(
 
                 lp_file_exists = os.path.isfile(lp_download_path)
 
+                # todo: rework this
                 if only_print_filenames and not lp_file_exists:
                     print(lp_download_path)
                 else:
-                    if lp_file_exists:
+                    if lp_file_exists: # live photo movie part is alreay there
                         lp_file_size = os.stat(lp_download_path).st_size
                         lp_photo_size = version["size"]
                         if lp_file_size != lp_photo_size:
                             lp_download_path = ("-%s." % lp_photo_size).join(
                                 lp_download_path.rsplit(".", 1)
                             )
+                            # filepath below download_dir to shorten output
+                            lp_download_filename = lp_download_path[len(directory)+1:]
                             logger.set_tqdm_description(
                                 "%s deduplicated." %
                                 truncate_middle(
-                                    lp_download_path, 96))
+                                    lp_download_filename, 60))
                             lp_file_exists = os.path.isfile(lp_download_path)
                         if lp_file_exists:
+                            # filepath below download_dir to shorten output
+                            lp_download_filename = lp_download_path[len(directory)+1:]
                             logger.set_tqdm_description(
                                 "%s already exists."
-                                % truncate_middle(lp_download_path, 96)
+                                % truncate_middle(lp_download_filename, 60)
                             )
-                    if not lp_file_exists:
-                        truncated_path = truncate_middle(lp_download_path, 96)
+                    else: # live photo movie part is alreay there
+                        # filepath below download_dir to shorten output
+                        lp_download_filename = lp_download_path[len(directory)+1:]
                         logger.set_tqdm_description(
-                            "Downloading %s" % truncated_path)
+                            "Downloading %s" % truncate_middle(lp_download_filename, 60))
                         download.download_media(
                             icloud, photo, lp_download_path, lp_size
                         )

--- a/icloudpd/download.py
+++ b/icloudpd/download.py
@@ -27,16 +27,19 @@ def update_mtime(photo, download_path):
             return
         set_utime(download_path, created_date)
 
+
 def set_utime(download_path, created_date):
     """Set date & time of the file"""
     ctime = time.mktime(created_date.timetuple())
     os.utime(download_path, (ctime, ctime))
 
+
 def download_media(icloud, photo, download_path, size):
     """Download the photo to path, with retries and error handling"""
     logger = setup_logger()
 
-    # get back the directory for the file to be downloaded and create it if not there already
+    # get back the directory for the file to be downloaded and create it if
+    # not there already
     download_dir = os.path.dirname(download_path)
 
     if not os.path.exists(download_dir):

--- a/tests/test_download_live_photos.py
+++ b/tests/test_download_live_photos.py
@@ -55,15 +55,15 @@ class DownloadLivePhotoTestCase(TestCase):
             print_result_exception(result)
 
             self.assertIn(
-                f"INFO     Downloading {os.path.join(base_dir, os.path.normpath('2020/11/04/IMG_0514_HEVC.MOV'))}",
+                f"INFO     Downloading {os.path.normpath('2020/11/04/IMG_0514_HEVC.MOV')}",
                 self._caplog.text,
             )
             self.assertIn(
-                f"INFO     Downloading {os.path.join(base_dir, os.path.normpath('2020/11/04/IMG_0514.HEIC'))}",
+                f"INFO     Downloading {os.path.normpath('2020/11/04/IMG_0514.HEIC')}",
                 self._caplog.text,
             )
             self.assertIn(
-                f"INFO     Downloading {os.path.join(base_dir, os.path.normpath('2020/11/04/IMG_0516.HEIC'))}",
+                f"INFO     Downloading {os.path.normpath('2020/11/04/IMG_0516.HEIC')}",
                 self._caplog.text,
             )
             self.assertIn(
@@ -117,19 +117,19 @@ class DownloadLivePhotoTestCase(TestCase):
                 self._caplog.text,
             )
             self.assertIn(
-                f"INFO     Downloading {os.path.join(base_dir, os.path.normpath('2020/11/04/IMG_0514.HEIC'))}",
+                f"INFO     Downloading {os.path.normpath('2020/11/04/IMG_0514.HEIC')}",
                 self._caplog.text,
             )
             self.assertIn(
-                f"INFO     {os.path.join(base_dir, os.path.normpath('2020/11/04/IMG_0514_HEVC.MOV'))} already exists.",
+                f"INFO     {os.path.normpath('2020/11/04/IMG_0514_HEVC.MOV')} already exists.",
                 self._caplog.text,
             )
             self.assertIn(
-                f"INFO     Downloading {os.path.join(base_dir, os.path.normpath('2020/11/04/IMG_0514.HEIC'))}",
+                f"INFO     Downloading {os.path.normpath('2020/11/04/IMG_0514.HEIC')}",
                 self._caplog.text,
             )
             self.assertIn(
-                f"INFO     {os.path.join(base_dir, os.path.normpath('2020/11/04/IMG_0516.HEIC'))} already exists.",
+                f"INFO     {os.path.normpath('2020/11/04/IMG_0516.HEIC')} already exists.",
                 self._caplog.text,
             )
             self.assertIn(

--- a/tests/test_download_photos.py
+++ b/tests/test_download_photos.py
@@ -69,19 +69,19 @@ class DownloadPhotoTestCase(TestCase):
                 self._caplog.text,
             )
             self.assertIn(
-                f"INFO     Downloading {os.path.join(base_dir, os.path.normpath('2018/07/31/IMG_7409.JPG'))}",
+                f"INFO     Downloading {os.path.normpath('2018/07/31/IMG_7409.JPG')}",
                 self._caplog.text,
             )
             self.assertNotIn(
-                "IMG_7409.MOV",
+                "IMG_7409.MOV", # skipped - downloading photos only
                 self._caplog.text,
             )
             self.assertIn(
-                f"INFO     {os.path.join(base_dir, os.path.normpath('2018/07/30/IMG_7408.JPG'))} already exists.",
+                f"INFO     {os.path.normpath('2018/07/30/IMG_7408.JPG')} already exists.",
                 self._caplog.text,
             )
             self.assertIn(
-                f"INFO     {os.path.join(base_dir, os.path.normpath('2018/07/30/IMG_7407.JPG'))} already exists.",
+                f"INFO     {os.path.normpath('2018/07/30/IMG_7407.JPG')} already exists.",
                 self._caplog.text,
             )
             self.assertIn(
@@ -170,7 +170,7 @@ class DownloadPhotoTestCase(TestCase):
                         self._caplog.text,
                     )
                     self.assertIn(
-                        f"INFO     Downloading {os.path.join(base_dir, os.path.normpath('2018/07/31/IMG_7409.JPG'))}",
+                        f"INFO     Downloading {os.path.normpath('2018/07/31/IMG_7409.JPG')}",
                         self._caplog.text,
                     )
                     # 2018:07:31 07:22:24 utc
@@ -225,7 +225,7 @@ class DownloadPhotoTestCase(TestCase):
                     self._caplog.text,
                 )
                 self.assertIn(
-                    f"INFO     Downloading {os.path.join(base_dir, os.path.normpath('2018/07/31/IMG_7409.JPG'))}",
+                    f"INFO     Downloading {os.path.normpath('2018/07/31/IMG_7409.JPG')}",
                     self._caplog.text,
                 )
                 self.assertIn(
@@ -286,11 +286,11 @@ class DownloadPhotoTestCase(TestCase):
                 self._caplog.text,
             )
             self.assertIn(
-                f"INFO     {os.path.join(base_dir, os.path.normpath('2018/07/31/IMG_7409.JPG'))} already exists.",
+                f"INFO     {os.path.normpath('2018/07/31/IMG_7409.JPG')} already exists.",
                 self._caplog.text,
             )
             self.assertIn(
-                f"INFO     {os.path.join(base_dir, os.path.normpath('2018/07/31/IMG_7409.MOV'))} already exists.",
+                f"INFO     {os.path.normpath('2018/07/31/IMG_7409.MOV')} already exists.",
                 self._caplog.text,
             )
             self.assertIn(
@@ -382,7 +382,7 @@ class DownloadPhotoTestCase(TestCase):
                     )
 
                     for f in files_to_skip:
-                        expected_message = f"INFO     {os.path.join(base_dir, os.path.normpath(f[0]))} already exists." 
+                        expected_message = f"INFO     {os.path.normpath(f[0])} already exists." 
                         self.assertIn(expected_message, self._caplog.text)
 
                     self.assertIn(
@@ -390,7 +390,7 @@ class DownloadPhotoTestCase(TestCase):
                         self._caplog.text,
                     )
                     self.assertNotIn(
-                        f"INFO     {os.path.join(base_dir, os.path.normpath('2018/07/30/IMG_7399-medium.MOV'))} already exists.", 
+                        f"INFO     {os.path.normpath('2018/07/30/IMG_7399-medium.MOV')} already exists.", 
                         self._caplog.text
                     )
 
@@ -811,7 +811,7 @@ class DownloadPhotoTestCase(TestCase):
                             self._caplog.text,
                         )
                         self.assertIn(
-                            f"INFO     Downloading {os.path.join(base_dir, os.path.normpath('2018/07/31/IMG_7409.JPG'))}",
+                            f"INFO     Downloading {os.path.normpath('2018/07/31/IMG_7409.JPG')}",
                             self._caplog.text,
                         )
                         self.assertIn(
@@ -935,7 +935,7 @@ class DownloadPhotoTestCase(TestCase):
                     self._caplog.text,
                 )
                 self.assertIn(
-                    f"INFO     Downloading {os.path.join(base_dir, os.path.normpath('2018/01/01/IMG_7409.JPG'))}",
+                    f"INFO     Downloading {os.path.normpath('2018/01/01/IMG_7409.JPG')}",
                     self._caplog.text,
                 )
                 self.assertIn(
@@ -998,7 +998,7 @@ class DownloadPhotoTestCase(TestCase):
                     self._caplog.text,
                 )
                 self.assertIn(
-                        f"INFO     Downloading {os.path.join(base_dir, os.path.normpath('5/01/01/IMG_7409.JPG'))}",
+                        f"INFO     Downloading {os.path.normpath('5/01/01/IMG_7409.JPG')}",
                         self._caplog.text,
                 )
                 self.assertIn(
@@ -1120,27 +1120,27 @@ class DownloadPhotoTestCase(TestCase):
                     self._caplog.text,
                 )
                 self.assertIn(
-                    f"INFO     {os.path.join(base_dir, os.path.normpath('2018/07/31/IMG_7409-1884695.JPG'))} deduplicated.",
+                    f"INFO     {os.path.normpath('2018/07/31/IMG_7409-1884695.JPG')} deduplicated.",
+                    self._caplog.text,
+                )
+                # self.assertIn(
+                    # f"INFO     Downloading {os.path.join(base_dir, os.path.normpath('2018/07/31/IMG_7409-1884695.JPG'))}",
+                    # self._caplog.text,
+                # )
+                self.assertIn(
+                    f"INFO     {os.path.normpath('2018/07/31/IMG_7409-3294075.MOV')} deduplicated.",
+                    self._caplog.text,
+                )
+                #self.assertIn(
+                    #f"INFO     Downloading {os.path.normpath('2018/07/31/IMG_7409-3294075.MOV')}",
+                    #self._caplog.text,
+                #)
+                self.assertIn(
+                    f"INFO     {os.path.normpath('2018/07/30/IMG_7408.JPG')} already exists.",
                     self._caplog.text,
                 )
                 self.assertIn(
-                    f"INFO     Downloading {os.path.join(base_dir, os.path.normpath('2018/07/31/IMG_7409-1884695.JPG'))}",
-                    self._caplog.text,
-                )
-                self.assertIn(
-                    f"INFO     {os.path.join(base_dir, os.path.normpath('2018/07/31/IMG_7409-3294075.MOV'))} deduplicated.",
-                    self._caplog.text,
-                )
-                self.assertIn(
-                    f"INFO     Downloading {os.path.join(base_dir, os.path.normpath('2018/07/31/IMG_7409-3294075.MOV'))}",
-                    self._caplog.text,
-                )
-                self.assertIn(
-                    f"INFO     {os.path.join(base_dir, os.path.normpath('2018/07/30/IMG_7408.JPG'))} already exists.",
-                    self._caplog.text,
-                )
-                self.assertIn(
-                    f"INFO     {os.path.join(base_dir, os.path.normpath('2018/07/30/IMG_7408.MOV'))} already exists.",
+                    f"INFO     {os.path.normpath('2018/07/30/IMG_7408.MOV')} already exists.",
                     self._caplog.text,
                 )
                 self.assertIn(
@@ -1217,7 +1217,7 @@ class DownloadPhotoTestCase(TestCase):
                         self._caplog.text,
                     )
                     self.assertIn(
-                        f"INFO     Downloading {os.path.join(base_dir, os.path.normpath('2018/07/31/IMG_7409.JPG'))}",
+                        f"INFO     Downloading {os.path.normpath('2018/07/31/IMG_7409.JPG')}",
                         self._caplog.text,
                     )
                     # 2018:07:31 07:22:24 utc
@@ -1273,7 +1273,7 @@ class DownloadPhotoTestCase(TestCase):
                 self._caplog.text,
             )
             self.assertIn(
-                f"INFO     Downloading {os.path.join(base_dir, os.path.normpath('2018/07/31/IMG_7409.JPG'))}",
+                f"INFO     Downloading {os.path.normpath('2018/07/31/IMG_7409.JPG')}",
                 self._caplog.text,
             )
             self.assertNotIn(


### PR DESCRIPTION
I worked on removing the download-path from the progress-bar. Closes #173 potentially. Aim is to shorten the printed out filenames. Relevant on shorter/smaller terminal sizes.

I'm not really sure if I like this change. I did not touch the behaviour of `--only-print-filenames`. I updated (most of the) tests accordingly and I'm not sure why some are failing now. Anyways I wanted to put this on for discussion. Some changes come from a linter run afterwards, so just code reformatting...

What do you think about this change?

PS: I also don't really like the more or less copy&paste but slightly different handling for photos vs. Live Photos and the deduce logic. Maybe worth some refactoring. But that's another issue...