### PR TITLE
fix platform list

### DIFF
--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -79,5 +79,5 @@ jobs:
       with:
         context: .
         file: ./Dockerfile
-        platforms: linux/amd64, linux/arm64
+        platforms: linux/amd64,linux/arm64
         push: false


### PR DESCRIPTION
I suspect that some recent changes in github and/or docker image used by github introduced stricter rules for platform format. This is a small fix for quality check -- no customer facing changes