### PR TITLE
Fix for #227 - smtp smtplib server_hostname

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.7.2 (2021-01-04)
+
+- fix: smtp server_hostname cannot be an empty [#227](https://github.com/icloud-photos-downloader/icloud_photos_downloader/issues/227)
+
 ## 1.7.1 (2020-11-15)
 
 - fix: dev docker build on windows correctly manages crlf for scripts

--- a/icloudpd/email_notifications.py
+++ b/icloudpd/email_notifications.py
@@ -15,7 +15,8 @@ def send_2sa_notification(
     from_addr = smtp_email if smtp_email else to_addr
     logger = setup_logger()
     logger.info("Sending 'two-step expired' notification via email...")
-    smtp = smtplib.SMTP()
+    #smtp = smtplib.SMTP()
+    smtp = smtplib.SMTP(smtp_host, smtp_port)
     smtp.set_debuglevel(0)
     smtp.connect(smtp_host, smtp_port)
     if not smtp_no_tls:

--- a/icloudpd/email_notifications.py
+++ b/icloudpd/email_notifications.py
@@ -15,7 +15,6 @@ def send_2sa_notification(
     from_addr = smtp_email if smtp_email else to_addr
     logger = setup_logger()
     logger.info("Sending 'two-step expired' notification via email...")
-    #smtp = smtplib.SMTP()
     smtp = smtplib.SMTP(smtp_host, smtp_port)
     smtp.set_debuglevel(0)
     smtp.connect(smtp_host, smtp_port)


### PR DESCRIPTION
"server_hostname cannot be an empty string or start with a leading dot"