### PR TITLE
remove pip feature flag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /app
 COPY requirements-pip.txt .
 COPY requirements.txt .
 RUN pip3 install -r requirements-pip.txt
-RUN pip3 install --use-feature=2020-resolver -r requirements.txt
+RUN pip3 install -r requirements.txt
 
 FROM base as test
 

--- a/scripts/install_deps
+++ b/scripts/install_deps
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -euo pipefail
 pip3 install -r requirements-pip.txt
-pip3 install --use-feature=2020-resolver -r requirements.txt -r requirements-test.txt -r requirements-dev.txt
+pip3 install -r requirements.txt -r requirements-test.txt -r requirements-dev.txt


### PR DESCRIPTION
latest pip uses new dependency resolved by default and spits warning that v21 will error with flag present, so removing the flag