### PR TITLE
Add option for a sender e-mail address

### DIFF
--- a/icloudpd/base.py
+++ b/icloudpd/base.py
@@ -171,6 +171,12 @@ CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
     metavar="<notification_email>",
 )
 @click.option(
+    "--sender-email",
+    help="Email address to send email notifications from. "
+    "Default: SMTP username",
+    metavar="<sender_email>",
+)
+@click.option(
     "--notification-script",
     type=click.Path(),
     help="Runs an external script when two factor authentication expires. "
@@ -220,6 +226,7 @@ def main(
         smtp_port,
         smtp_no_tls,
         notification_email,
+        sender_email,
         log_level,
         no_progress_bar,
         notification_script,
@@ -270,6 +277,7 @@ def main(
                 smtp_port,
                 smtp_no_tls,
                 notification_email,
+                sender_email,
             )
         sys.exit(1)
 

--- a/icloudpd/email_notifications.py
+++ b/icloudpd/email_notifications.py
@@ -8,11 +8,11 @@ from icloudpd.logger import setup_logger
 
 
 def send_2sa_notification(
-        smtp_email, smtp_password, smtp_host, smtp_port, smtp_no_tls, to_addr
+        smtp_username, smtp_password, smtp_host, smtp_port, smtp_no_tls, to_addr, from_addr
 ):
     """Send an email notification when 2SA is expired"""
-    to_addr = to_addr if to_addr else smtp_email
-    from_addr = smtp_email if smtp_email else to_addr
+    to_addr = to_addr if to_addr else smtp_username
+    from_addr = from_addr if from_addr else smtp_username
     logger = setup_logger()
     logger.info("Sending 'two-step expired' notification via email...")
     smtp = smtplib.SMTP(smtp_host, smtp_port)
@@ -23,8 +23,8 @@ def send_2sa_notification(
     if not smtp_no_tls:
         smtp.starttls()
 
-    if smtp_email is not None or smtp_password is not None:
-        smtp.login(smtp_email, smtp_password)
+    if smtp_username is not None or smtp_password is not None:
+        smtp.login(smtp_username, smtp_password)
 
     subj = "icloud_photos_downloader: Two step authentication has expired"
     date = datetime.datetime.now().strftime("%d/%m/%Y %H:%M")


### PR DESCRIPTION
This could prove useful when using a transactional e-mail service like Mailjet, where the SMTP username is a string of length 32 (and not an actual e-mail address).