### PR TITLE
fix flaky test on test_logger.py::LoggerTestCase::test_logger_tqdm_fallback

### DIFF
--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -51,3 +51,5 @@ class LoggerTestCase(TestCase):
         logger.tqdm_write("qux")
         logger.tqdm.write.assert_called_once_with("qux")
         logger.log.assert_not_called
+
+        logger.set_tqdm(None)


### PR DESCRIPTION
This PR aims to fix the flaky test on **test_logger.py::LoggerTestCase::test_logger_tqdm_fallback**  so the test could pass for multiple test runs 

#### The result

The test can pass when running only once, but fail when running the test suit multiple times. When asserting the mock function is called, it is not called.

#### Steps to reproduce the issue

1.  install pytest flaky finder with `pip install pytest-flakefinder`
2.  run pytest with flake-finder with command  `pytest -k test_logger.py --flake-finder`

#### Issue of the code

The reason is the code doesn't reset the logger.tqdm, which causes the magic mock tqdm to still exist after the testing method, cause the test to fail on the second run in this line `logger.set_tqdm_description("foo")` since the tqdm has already existed. 

#### Proposed solution
Adding one line on the end of testing method to remove the tqdm mock object via `logger.set_tqdm(None)`

