### PR TITLE
add icloud script to src dist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix: add `icloud` script to the source distribution [#594](https://github.com/icloud-photos-downloader/icloud_photos_downloader/issues/594)
+
 ## 1.11.0 (2023-02-24)
 
 - feature: add experimental mode for new cli

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",
     ],
-    entry_points={"console_scripts": ["icloudpd = icloudpd.base:main"]},
+    entry_points={"console_scripts": ["icloudpd = icloudpd.base:main", "icloud = pyicloud_ipd.cmdline:main"]},
     long_description=long_description,
     long_description_content_type='text/markdown'
 )


### PR DESCRIPTION
- fix: add `icloud` script to the source distribution [#594](https://github.com/icloud-photos-downloader/icloud_photos_downloader/issues/594)
