### PR TITLE
Skip download if file exists without checking for file size (in bytes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,9 @@ Options:
                                   will be downloaded (not including files that
                                   are already downloaded.)(Does not download
                                   or delete any files.)
+  --ignore-local-filesize         Skipping download if file(name) exists
+                                  locally regardless of the difference in size.
+                                  (Dropbox online-only files report 0 size)
   --folder-structure <folder_structure>
                                   Folder structure (default: {:%Y/%m/%d}). If
                                   set to 'none' all photos will just be placed


### PR DESCRIPTION
Docker online-only files report 0 bytes size on newer macOS versions. As I keep "local" iCloud photos copy on in Docker it is useful to ignore file size on download.