### PR TITLE
Skip download if file exists without checking for file size (in bytes) 

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,9 @@ Options:
                                   will be downloaded (not including files that
                                   are already downloaded.)(Does not download
                                   or delete any files.)
+  --ignore-local-filesize         Skipping download if file(name) exists
+                                  locally regardless of the difference in size.
+                                  (Dropbox online-only files report 0 size)
   --folder-structure <folder_structure>
                                   Folder structure (default: {:%Y/%m/%d}). If
                                   set to 'none' all photos will just be placed

--- a/tests/test_download_live_photos.py
+++ b/tests/test_download_live_photos.py
@@ -18,6 +18,7 @@ from icloudpd.base import main
 from tests.helpers.print_result_exception import print_result_exception
 import inspect
 import glob
+from icloudpd.string_helpers import truncate_middle
 
 vcr = VCR(decode_compressed_response=True)
 
@@ -156,6 +157,91 @@ class DownloadLivePhotoTestCase(TestCase):
             )
             self.assertIn(
                 f"INFO     {os.path.join(base_dir, os.path.normpath('2020/11/04/IMG_0516.HEIC'))} already exists.",
+                self._caplog.text,
+            )
+            self.assertIn(
+                "INFO     All photos have been downloaded!", self._caplog.text
+            )
+            assert result.exit_code == 0
+
+
+        files_in_result = glob.glob(os.path.join(base_dir, "**/*.*"), recursive=True)
+
+        assert sum(1 for _ in files_in_result) == len(files_to_download) + len(files_to_create)
+
+        for file_name in files_to_download + ([file_name for (file_name, _) in files_to_create]):
+            assert os.path.exists(os.path.join(base_dir, os.path.normpath(file_name))), f"file {file_name} expected, but not found"
+
+    def test_skip_existing_live_photodownloads_emptyfiles(self):
+        base_dir = os.path.normpath(f"tests/fixtures/Photos/{inspect.stack()[0][3]}")
+        if os.path.exists(base_dir):
+            shutil.rmtree(base_dir)
+        os.makedirs(base_dir)
+
+        files_to_create = [
+            ("2020/11/04/IMG_0516.HEIC", 0),
+            ("2020/11/04/IMG_0514_HEVC.MOV", 0),
+        ]
+
+        files_to_download = [
+            "2020/11/04/IMG_0514.HEIC",
+            "2020/11/04/IMG_0512.HEIC",
+            "2020/11/04/IMG_0512_HEVC.MOV"
+        ]
+
+        # simulate that some expected files are there with correct sizes
+        os.makedirs(os.path.join(base_dir, "2020/11/04"))
+        # one photo and one movie are already there and should be skipped
+        # Create dummies with the correct size
+        for (file_name, file_size) in files_to_create:
+            with open(os.path.join(base_dir, file_name), "a") as f:
+                f.truncate(file_size)
+
+        with vcr.use_cassette("tests/vcr_cassettes/download_live_photos.yml"):
+            # Pass fixed client ID via environment variable
+            runner = CliRunner(env={
+                "CLIENT_ID": "DE309E26-942E-11E8-92F5-14109FE0B321"
+            })
+            result = runner.invoke(
+                main,
+                [
+                    "--username",
+                    "jdoe@gmail.com",
+                    "--password",
+                    "password1",
+                    "--recent",
+                    "3",
+                    "--ignore-local-filesize",
+                    "--no-progress-bar",
+                    "--threads-num",
+                    1,
+                    "-d",
+                    base_dir,
+                ],
+            )
+            print_result_exception(result)
+
+            self.assertIn(
+                "DEBUG    Looking up all photos and videos from album All Photos...", self._caplog.text
+            )
+            self.assertIn(
+                f"INFO     Downloading 3 original photos and videos to {base_dir} ...",
+                self._caplog.text,
+            )
+            self.assertIn(
+                f"INFO     Downloading {os.path.join(base_dir, os.path.normpath('2020/11/04/IMG_0514.HEIC'))}",
+                self._caplog.text,
+            )
+            self.assertIn(
+                f"INFO     {truncate_middle(os.path.join(base_dir, os.path.normpath('2020/11/04/IMG_0514_HEVC.MOV')), 96)} already exists (size differs, though).",
+                self._caplog.text,
+            )
+            self.assertIn(
+                f"INFO     Downloading {os.path.join(base_dir, os.path.normpath('2020/11/04/IMG_0514.HEIC'))}",
+                self._caplog.text,
+            )
+            self.assertIn(
+                f"INFO     {os.path.join(base_dir, os.path.normpath('2020/11/04/IMG_0516.HEIC'))} already exists (size differs, though).",
                 self._caplog.text,
             )
             self.assertIn(


### PR DESCRIPTION
Added a cmdline switch to skip re-downloading if the size (in bytes) does not match.
Docker online-only files report 0 bytes size on newer macOS versions. As I keep "local" iCloud photos copy on in Docker it is useful to ignore file size on download.
Linter has no complaints.
Tests added for the new --ignore-local-filesize switch.