### PR TITLE
Add AUR link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ We aim to release new versions once a week (Friday), if there is something worth
 
 There are three ways to run `icloudpd`:
 1. Download executable for your platform from the Github [Releases](https://github.com/icloud-photos-downloader/icloud_photos_downloader/releases) and run it
-1. Use package manager to install, update, and, in some cases, run ([Docker](README_DOCKER.md), [PyPI](README_PYPI.md), Experimental: [Npm](README_NPM.md))
+1. Use package manager to install, update, and, in some cases, run ([Docker](README_DOCKER.md), [PyPI](README_PYPI.md), [AUR](https://aur.archlinux.org/packages/icloudpd-bin), Experimental: [Npm](README_NPM.md))
 1. Build and run from the source
 
 ## Features


### PR DESCRIPTION
Hi,

Thanks for the nice tool! Since a package was not available on the AUR yet I created a simple PKGBUILD that sets up the icloudpd binary. This should make using and updating the tool a bit easier for Arch users. Because this provides another way to install the package I added this option to the README. If there is any additional documentation you'd like me to write I'd be happy to do so, just let me know.