### PR TITLE
Enhance logging for IOError in file writing process

### DIFF
--- a/src/icloudpd/download.py
+++ b/src/icloudpd/download.py
@@ -151,13 +151,14 @@ def download_media(
                 )
                 time.sleep(wait_time)
 
-        except IOError:
+        except IOError as ex:
             logger.error(
                 "IOError while writing file to %s. " +
+                "Error: %s (errno: %d)."+
                 "You might have run out of disk space, or the file " +
                 "might be too large for your OS. " +
                 "Skipping this file...",
-                download_path
+                download_path, ex.strerror, ex.errno
             )
             break
     else:


### PR DESCRIPTION
In my use case, a large number of download tasks reported an IOError, but the files were actually downloaded successfully. Upon reviewing the source code, I found that the current error message for IOError is static. Therefore, I aim to output the real error reason to improve clarity and debugging.