### PR TITLE
fix problem : photos of Recently Deleted won't be expunged with   --album "Recently Deleted"  --delete-after-download

### DIFF
--- a/src/icloudpd/base.py
+++ b/src/icloudpd/base.py
@@ -1018,7 +1018,7 @@ def delete_photo(
     post_data = json.dumps(
         {
             "atomic": True,
-            "desiredKeys": ["isDeleted"],
+            #"desiredKeys": ["isDeleted"],#this is not needed,2024-07-29
             "operations": [
                 {
                     "operationType": "update",
@@ -1331,8 +1331,12 @@ def core(
                         break
                     item = next(photos_iterator)
                     if download_photo(consecutive_files_found, item) and delete_after_download:
+                        if album == "Recently Deleted":
+                            del_photo=expunge_photo 
+                        else:
+                            del_photo=delete_photo
                         delete_local = partial(
-                            delete_photo_dry_run if dry_run else delete_photo,
+                            delete_photo_dry_run if dry_run else del_photo,
                             logger,
                             icloud.photos,
                             library_object,
@@ -1395,3 +1399,37 @@ def core(
                 break  # pragma: no cover
 
     return 0
+
+
+def expunge_photo(
+    logger: logging.Logger,
+    photo_service: PhotosService,
+    library_object: PhotoLibrary,
+    photo: PhotoAsset,
+) -> None:
+    """Expunge a photo from the Recently Deleted."""
+    clean_filename_local = photo.filename
+    logger.debug("Expunging %s in Recently Deleted...", clean_filename_local)
+    url = (
+        f"{photo_service._service_endpoint}/records/modify?"
+        f"{urllib.parse.urlencode(photo_service.params)}"
+    )
+    post_data = json.dumps(
+        {
+            "atomic": True,
+            "operations": [
+                {
+                    "operationType": "update",
+                    "record": {
+                        "fields": {"isExpunged": {"value": 1}},
+                        "recordChangeTag": photo._asset_record["recordChangeTag"],
+                        "recordName": photo._asset_record["recordName"],
+                        "recordType": "CPLAsset",
+                    },
+                }
+            ],
+            "zoneID": library_object.zone_id,
+        }
+    )
+    photo_service.session.post(url, data=post_data, headers={"Content-type": "application/json"})
+    logger.info("Expunged %s in Recently Deleted", clean_filename_local)


### PR DESCRIPTION
when expunge photos of Recently Deleted , the post date should with "fields": {"isExpunged": {"value": 1}} not "fields": {"isDeleted": {"value": 1}}