### PR TITLE
fix: failed to login non-2FA account for the first attempt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- fix: failed to login non-2FA account for the first attempt [#1012](https://github.com/icloud-photos-downloader/icloud_photos_downloader/issues/1012)
 - fix: log more information for authentication error [#1010](https://github.com/icloud-photos-downloader/icloud_photos_downloader/issues/1010)
 - feature: add support for XMP files with `--xmp-sidecar` parameter [#448](https://github.com/icloud-photos-downloader/icloud_photos_downloader/issues/448), [#102](https://github.com/icloud-photos-downloader/icloud_photos_downloader/issues/102), [#789](https://github.com/icloud-photos-downloader/icloud_photos_downloader/issues/789)
 

--- a/src/pyicloud_ipd/base.py
+++ b/src/pyicloud_ipd/base.py
@@ -194,13 +194,6 @@ class PyiCloudService:
             LOGGER.debug("Authenticating as %s", self.user["accountName"])
 
             headers = self._get_auth_headers()
-            scnt = self.session_data.get("scnt")
-            if scnt:
-                headers["scnt"] = scnt
-
-            session_id = self.session_data.get("session_id")
-            if session_id:
-                headers["X-Apple-ID-Session-Id"] = session_id
 
             class SrpPassword():
                 # srp uses the encoded password at process_challenge(), thus set_encrypt_info() should be called before that
@@ -271,6 +264,7 @@ class PyiCloudService:
                     pass
                 elif response.status_code == 412:
                     # non 2FA account returns 412 "precondition no met"
+                    headers = self._get_auth_headers()
                     response = self.session.post(
                         "%s/repair/complete" % self.AUTH_ENDPOINT,
                         data=json.dumps({}),
@@ -359,6 +353,14 @@ class PyiCloudService:
             "X-Apple-OAuth-State": self.client_id,
             "X-Apple-Widget-Key": "d39ba9916b7251055b22c7f910e2ea796ee65e98b2ddecea8f5dde8d9d1a815d",
         }
+        scnt = self.session_data.get("scnt")
+        if scnt:
+            headers["scnt"] = scnt
+
+        session_id = self.session_data.get("session_id")
+        if session_id:
+            headers["X-Apple-ID-Session-Id"] = session_id
+
         if overrides:
             headers.update(overrides)
         return headers
@@ -514,14 +516,6 @@ class PyiCloudService:
 
         headers = self._get_auth_headers({"Accept": "application/json"})
 
-        scnt = self.session_data.get("scnt")
-        if scnt:
-            headers["scnt"] = scnt
-        
-        session_id = self.session_data.get("session_id")
-        if session_id:
-            headers["X-Apple-ID-Session-Id"] = session_id
-
         try:
             self.session.post(
                 "%s/verify/trusteddevice/securitycode" % self.AUTH_ENDPOINT,
@@ -543,14 +537,6 @@ class PyiCloudService:
     def trust_session(self) -> bool:
         """Request session trust to avoid user log in going forward."""
         headers = self._get_auth_headers()
-
-        scnt = self.session_data.get("scnt")
-        if scnt:
-            headers["scnt"] = scnt
-        
-        session_id = self.session_data.get("session_id")
-        if session_id:
-            headers["X-Apple-ID-Session-Id"] = session_id
 
         try:
             self.session.get(

--- a/tests/vcr_cassettes/auth_non_2fa.yml
+++ b/tests/vcr_cassettes/auth_non_2fa.yml
@@ -114,6 +114,8 @@ interactions:
       X-Apple-OAuth-Response-Type: ['code']
       X-Apple-OAuth-State: ['EC5646DE-9423-11E8-BF21-14109FE0B321']
       X-Apple-Widget-Key: ['d39ba9916b7251055b22c7f910e2ea796ee65e98b2ddecea8f5dde8d9d1a815d']
+      scnt: ['scnt-1234567890']
+      X-Apple-ID-Session-Id: ['sess-1234567890']
     method: POST
     uri: https://idmsa.apple.com/appleauth/auth/repair/complete
   response:


### PR DESCRIPTION
Fixes https://github.com/icloud-photos-downloader/icloud_photos_downloader/issues/1012

- Update headers with `self.session_data` in `_get_auth_headers()` to avoid duplicate code.
- Header of `/repair/complete` request should be reacquired to include `scnt` and `session_id` .