### PR TITLE
Add curl to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,18 @@
 FROM alpine:3.18 AS runtime_amd64_none
 ENV MUSL_LOCPATH="/usr/share/i18n/locales/musl"
-RUN apk update && apk add --no-cache tzdata musl-locales musl-locales-lang
+RUN apk update && apk add --no-cache tzdata musl-locales musl-locales-lang curl
 WORKDIR /app
 COPY dist/icloudpd-ex-*.*.*-linux-musl-amd64 icloudpd_ex
 
 FROM alpine:3.18 AS runtime_arm64_none
 ENV MUSL_LOCPATH="/usr/share/i18n/locales/musl"
-RUN apk update && apk add --no-cache tzdata musl-locales musl-locales-lang
+RUN apk update && apk add --no-cache tzdata musl-locales musl-locales-lang curl
 WORKDIR /app
 COPY dist/icloudpd-ex-*.*.*-linux-musl-arm64 icloudpd_ex
 
 FROM alpine:3.18 AS runtime_arm_v7
 ENV MUSL_LOCPATH="/usr/share/i18n/locales/musl"
-RUN apk update && apk add --no-cache tzdata musl-locales musl-locales-lang
+RUN apk update && apk add --no-cache tzdata musl-locales musl-locales-lang curl
 WORKDIR /app
 COPY dist/icloudpd-ex-*.*.*-linux-musl-arm32v7 icloudpd_ex
 


### PR DESCRIPTION
When mounting a notification script in the docker container, curl is unavailable which limits most use cases. Busybox's wget is preinstalled, but it doesn't support authentication.

This PR add curl to all the images.