### PR TITLE
bug: keep_icloud_recent days should be inside the photo loop

### DIFF
--- a/tests/test_keep_icloud_mode.py
+++ b/tests/test_keep_icloud_mode.py
@@ -215,63 +215,111 @@ class KeepICloudModeTestCases(TestCase):
             ("2018/07/30", "IMG_7408.JPG", 1151066),
             ("2018/07/30", "IMG_7407.JPG", 656257),
         ]
+        with mock.patch("datetime.datetime", wraps=datetime.datetime) as dt_mock:
+            days_old = 10
+            mock_now = datetime.datetime(2018, 7, 31, tzinfo=datetime.timezone.utc)
+            dt_mock.now.return_value = mock_now + datetime.timedelta(days=days_old)
+            data_dir, result = run_icloudpd_test(
+                self.assertEqual,
+                self.root_path,
+                base_dir,
+                "listing_photos_keep_icloud_recent_days.yml",
+                files_to_create,
+                [],
+                [
+                    "--username",
+                    "jdoe@gmail.com",
+                    "--password",
+                    "password1",
+                    "--recent",
+                    "3",
+                    "--skip-videos",
+                    "--skip-live-photos",
+                    "--no-progress-bar",
+                    "--threads-num",
+                    "1",
+                    "--keep-icloud-recent-days",
+                    "0",
+                ],
+            )
 
-        orig_download = PhotoAsset.download
+            self.assertIn(
+                "DEBUG    Looking up all photos from album All Photos...", self._caplog.text
+            )
+            self.assertIn(
+                f"INFO     Downloading 3 original photos to {data_dir} ...",
+                self._caplog.text,
+            )
+            self.assertIn(
+                "INFO     Deleted IMG_7409.JPG in iCloud",
+                self._caplog.text,
+            )
+            self.assertIn(
+                "INFO     Deleted IMG_7408.JPG in iCloud",
+                self._caplog.text,
+            )
+            self.assertIn(
+                "INFO     Deleted IMG_7407.JPG in iCloud",
+                self._caplog.text,
+            )
+            self.assertIn("INFO     All photos have been downloaded", self._caplog.text)
+            assert result.exit_code == 0
 
-        def mocked_download(pa: PhotoAsset, _url: str) -> Response:
-            if not hasattr(PhotoAsset, "already_downloaded"):
-                response = orig_download(pa, _url)
-                setattr(PhotoAsset, "already_downloaded", True)  # noqa: B010
-                return response
-            return mock.MagicMock()
 
-        with mock.patch.object(PhotoAsset, "download", new=mocked_download):  # noqa: SIM117
-            with mock.patch("datetime.datetime", wraps=datetime.datetime) as dt_mock:
-                days_old = 10
-                mock_now = datetime.datetime(2018, 7, 31, tzinfo=datetime.timezone.utc)
-                dt_mock.now.return_value = mock_now + datetime.timedelta(days=days_old)
-                data_dir, result = run_icloudpd_test(
-                    self.assertEqual,
-                    self.root_path,
-                    base_dir,
-                    "listing_photos_keep_icloud_recent_days.yml",
-                    files_to_create,
-                    [],
-                    [
-                        "--username",
-                        "jdoe@gmail.com",
-                        "--password",
-                        "password1",
-                        "--recent",
-                        "3",
-                        "--skip-videos",
-                        "--skip-live-photos",
-                        "--no-progress-bar",
-                        "--threads-num",
-                        "1",
-                        "--keep-icloud-recent-days",
-                        "0",
-                    ],
-                )
+    def test_keep_icloud_recent_days_keeps_some(self) -> None:
+        base_dir = os.path.join(self.fixtures_path, inspect.stack()[0][3])
 
-                self.assertIn(
-                    "DEBUG    Looking up all photos from album All Photos...", self._caplog.text
-                )
-                self.assertIn(
-                    f"INFO     Downloading 3 original photos to {data_dir} ...",
-                    self._caplog.text,
-                )
-                self.assertIn(
-                    "INFO     Deleted IMG_7409.JPG in iCloud",
-                    self._caplog.text,
-                )
-                self.assertIn(
-                    "INFO     Deleted IMG_7408.JPG in iCloud",
-                    self._caplog.text,
-                )
-                self.assertIn(
-                    "INFO     Deleted IMG_7407.JPG in iCloud",
-                    self._caplog.text,
-                )
-                self.assertIn("INFO     All photos have been downloaded", self._caplog.text)
-                assert result.exit_code == 0
+        files_to_create = [
+            ("2018/07/31", "IMG_7409.JPG", 1884695), # 0 days old, should be kept
+            ("2018/07/30", "IMG_7408.JPG", 1151066), # 1 days old, should be deleted
+            ("2018/07/30", "IMG_7407.JPG", 656257), # 1 days old, should be deleted
+        ]
+        with mock.patch("datetime.datetime", wraps=datetime.datetime) as dt_mock:
+            days_old = 1
+            mock_now = datetime.datetime(2018, 7, 31, tzinfo=datetime.timezone.utc)
+            dt_mock.now.return_value = mock_now + datetime.timedelta(days=days_old)
+            data_dir, result = run_icloudpd_test(
+                self.assertEqual,
+                self.root_path,
+                base_dir,
+                "listing_photos_keep_icloud_recent_days.yml",
+                files_to_create,
+                [],
+                [
+                    "--username",
+                    "jdoe@gmail.com",
+                    "--password",
+                    "password1",
+                    "--recent",
+                    "3",
+                    "--skip-videos",
+                    "--skip-live-photos",
+                    "--no-progress-bar",
+                    "--threads-num",
+                    "1",
+                    "--keep-icloud-recent-days",
+                    "1",
+                ],
+            )
+
+            self.assertIn(
+                "DEBUG    Looking up all photos from album All Photos...", self._caplog.text
+            )
+            self.assertIn(
+                f"INFO     Downloading 3 original photos to {data_dir} ...",
+                self._caplog.text,
+            )
+            self.assertNotIn(
+                "INFO     Deleted IMG_7409.JPG in iCloud",
+                self._caplog.text,
+            )
+            self.assertIn(
+                "INFO     Deleted IMG_7408.JPG in iCloud",
+                self._caplog.text,
+            )
+            self.assertIn(
+                "INFO     Deleted IMG_7407.JPG in iCloud",
+                self._caplog.text,
+            )
+            self.assertIn("INFO     All photos have been downloaded", self._caplog.text)
+            assert result.exit_code == 0

--- a/tests/test_keep_icloud_mode.py
+++ b/tests/test_keep_icloud_mode.py
@@ -4,10 +4,8 @@ import os
 from unittest import TestCase, mock
 
 import pytest
-from requests import Response
 from vcr import VCR
 
-from pyicloud_ipd.services.photos import PhotoAsset
 from tests.helpers import path_from_project_root, run_icloudpd_test
 
 vcr = VCR(decode_compressed_response=True, record_mode="none")
@@ -265,14 +263,13 @@ class KeepICloudModeTestCases(TestCase):
             self.assertIn("INFO     All photos have been downloaded", self._caplog.text)
             assert result.exit_code == 0
 
-
     def test_keep_icloud_recent_days_keeps_some(self) -> None:
         base_dir = os.path.join(self.fixtures_path, inspect.stack()[0][3])
 
         files_to_create = [
-            ("2018/07/31", "IMG_7409.JPG", 1884695), # 0 days old, should be kept
-            ("2018/07/30", "IMG_7408.JPG", 1151066), # 1 days old, should be deleted
-            ("2018/07/30", "IMG_7407.JPG", 656257), # 1 days old, should be deleted
+            ("2018/07/31", "IMG_7409.JPG", 1884695),  # 0 days old, should be kept
+            ("2018/07/30", "IMG_7408.JPG", 1151066),  # 1 days old, should be deleted
+            ("2018/07/30", "IMG_7407.JPG", 656257),  # 1 days old, should be deleted
         ]
         with mock.patch("datetime.datetime", wraps=datetime.datetime) as dt_mock:
             days_old = 1

--- a/tests/test_keep_icloud_mode.py
+++ b/tests/test_keep_icloud_mode.py
@@ -4,11 +4,11 @@ import os
 from unittest import TestCase, mock
 
 import pytest
-from vcr import VCR
 from requests import Response
+from vcr import VCR
 
-from tests.helpers import path_from_project_root, run_icloudpd_test
 from pyicloud_ipd.services.photos import PhotoAsset
+from tests.helpers import path_from_project_root, run_icloudpd_test
 
 vcr = VCR(decode_compressed_response=True, record_mode="none")
 
@@ -226,52 +226,52 @@ class KeepICloudModeTestCases(TestCase):
             return mock.MagicMock()
 
         with mock.patch.object(PhotoAsset, "download", new=mocked_download):  # noqa: SIM117
-          with mock.patch("datetime.datetime", wraps=datetime.datetime) as dt_mock:
-              days_old = 10
-              mock_now = datetime.datetime(2018, 7, 31, tzinfo=datetime.timezone.utc)
-              dt_mock.now.return_value = mock_now + datetime.timedelta(days=days_old)
-              data_dir, result = run_icloudpd_test(
-                  self.assertEqual,
-                  self.root_path,
-                  base_dir,
-                  "listing_photos_keep_icloud_recent_days.yml",
-                  files_to_create,
-                  [],
-                  [
-                      "--username",
-                      "jdoe@gmail.com",
-                      "--password",
-                      "password1",
-                      "--recent",
-                      "3",
-                      "--skip-videos",
-                      "--skip-live-photos",
-                      "--no-progress-bar",
-                      "--threads-num",
-                      "1",
-                      "--keep-icloud-recent-days",
-                      "0",
-                  ],
-              )
+            with mock.patch("datetime.datetime", wraps=datetime.datetime) as dt_mock:
+                days_old = 10
+                mock_now = datetime.datetime(2018, 7, 31, tzinfo=datetime.timezone.utc)
+                dt_mock.now.return_value = mock_now + datetime.timedelta(days=days_old)
+                data_dir, result = run_icloudpd_test(
+                    self.assertEqual,
+                    self.root_path,
+                    base_dir,
+                    "listing_photos_keep_icloud_recent_days.yml",
+                    files_to_create,
+                    [],
+                    [
+                        "--username",
+                        "jdoe@gmail.com",
+                        "--password",
+                        "password1",
+                        "--recent",
+                        "3",
+                        "--skip-videos",
+                        "--skip-live-photos",
+                        "--no-progress-bar",
+                        "--threads-num",
+                        "1",
+                        "--keep-icloud-recent-days",
+                        "0",
+                    ],
+                )
 
-              self.assertIn(
-                  "DEBUG    Looking up all photos from album All Photos...", self._caplog.text
-              )
-              self.assertIn(
-                  f"INFO     Downloading 3 original photos to {data_dir} ...",
-                  self._caplog.text,
-              )
-              self.assertIn(
-                  "INFO     Deleted IMG_7409.JPG in iCloud",
-                  self._caplog.text,
-              )
-              self.assertIn(
-                  "INFO     Deleted IMG_7408.JPG in iCloud",
-                  self._caplog.text,
-              )
-              self.assertIn(
-                  "INFO     Deleted IMG_7407.JPG in iCloud",
-                  self._caplog.text,
-              )
-              self.assertIn("INFO     All photos have been downloaded", self._caplog.text)
-              assert result.exit_code == 0
+                self.assertIn(
+                    "DEBUG    Looking up all photos from album All Photos...", self._caplog.text
+                )
+                self.assertIn(
+                    f"INFO     Downloading 3 original photos to {data_dir} ...",
+                    self._caplog.text,
+                )
+                self.assertIn(
+                    "INFO     Deleted IMG_7409.JPG in iCloud",
+                    self._caplog.text,
+                )
+                self.assertIn(
+                    "INFO     Deleted IMG_7408.JPG in iCloud",
+                    self._caplog.text,
+                )
+                self.assertIn(
+                    "INFO     Deleted IMG_7407.JPG in iCloud",
+                    self._caplog.text,
+                )
+                self.assertIn("INFO     All photos have been downloaded", self._caplog.text)
+                assert result.exit_code == 0

--- a/tests/vcr_cassettes/listing_photos_keep_icloud_recent_days.yml
+++ b/tests/vcr_cassettes/listing_photos_keep_icloud_recent_days.yml
@@ -44747,4 +44747,64 @@ interactions:
     headers:
       Content-type: application/json
     status: {code: 200, message: OK}
+- request:
+    body: '{"atomic": true, "desiredKeys": ["isDeleted"], "operations": [{"operationType":
+      "update", "record": {"fields": {"isDeleted": {"value": 1}}, "recordChangeTag":
+      "49lh", "recordName": "577DE5DB-44CF-470B-9791-11F4A5C4A99C", "recordType":
+      "CPLAsset"}}], "zoneID": {"zoneName": "PrimarySync"}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '288'
+      Content-type:
+      - application/json
+      Origin:
+      - https://www.icloud.com
+      Referer:
+      - https://www.icloud.com/
+      User-Agent:
+      - Opera/9.52 (X11; Linux i686; U; en)
+    method: POST
+    uri: https://p61-ckdatabasews.icloud.com/database/1/com.apple.photos.cloud/production/private/records/modify?clientBuildNumber=17DHotfix5&clientMasteringNumber=17DHotfix5&ckjsBuildVersion=17DProjectDev77&ckjsVersion=2.0.5&clientId=DE309E26-942E-11E8-92F5-14109FE0B321&dsid=12345678901&remapEnums=True&getCurrentSyncToken=True
+  response:
+    body:
+      string: "{}"
+    headers:
+      Content-type: application/json
+    status: {code: 200, message: OK}
+- request:
+    body: '{"atomic": true, "desiredKeys": ["isDeleted"], "operations": [{"operationType":
+      "update", "record": {"fields": {"isDeleted": {"value": 1}}, "recordChangeTag":
+      "49lh", "recordName": "135B4CE4-050D-41CE-ABD2-7AE6E5FA1E25", "recordType":
+      "CPLAsset"}}], "zoneID": {"zoneName": "PrimarySync"}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '288'
+      Content-type:
+      - application/json
+      Origin:
+      - https://www.icloud.com
+      Referer:
+      - https://www.icloud.com/
+      User-Agent:
+      - Opera/9.52 (X11; Linux i686; U; en)
+    method: POST
+    uri: https://p61-ckdatabasews.icloud.com/database/1/com.apple.photos.cloud/production/private/records/modify?clientBuildNumber=17DHotfix5&clientMasteringNumber=17DHotfix5&ckjsBuildVersion=17DProjectDev77&ckjsVersion=2.0.5&clientId=DE309E26-942E-11E8-92F5-14109FE0B321&dsid=12345678901&remapEnums=True&getCurrentSyncToken=True
+  response:
+    body:
+      string: "{}"
+    headers:
+      Content-type: application/json
+    status: {code: 200, message: OK}
 version: 1


### PR DESCRIPTION
In #1040 I mistakenly kept the handling of `keep_icloud_recent_days` outside of the main photo iteration, which meant we only "cleaned up" the last photo in the loop.

This moves it inside the loop, then updates a test to verify multiple files will be deleted as expected.