### PR TITLE
feature: the icloud email username is now included in the email about 2sa authentication failing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,7 +77,7 @@
 
 ## 1.23.0 (2024-07-25)
 
-- feature: update webui and allow to cancel and resume sync
+- feature: update webui and allow to cancel and resume sync 
 - deprecate linux 386 and arm v6 support
 - add linux musl builds
 
@@ -265,7 +265,7 @@
 
 ## 1.9.0 (2023-02-10)
 
-- fix: replace invalid chars in filenames with '\_' [#378](https://github.com/icloud-photos-downloader/icloud_photos_downloader/issues/378)
+- fix: replace invalid chars in filenames with '_' [#378](https://github.com/icloud-photos-downloader/icloud_photos_downloader/issues/378)
 - feature: add `--domain` parameter to support mainland China [#572](https://github.com/icloud-photos-downloader/icloud_photos_downloader/issues/572), [#545](https://github.com/icloud-photos-downloader/icloud_photos_downloader/issues/545)
 - feature: add `linux/arm/v7` and `linux/arm/v6` docker image [#434](https://github.com/icloud-photos-downloader/icloud_photos_downloader/issues/434)
 
@@ -290,7 +290,7 @@
 
 - fix: smtp server_hostname cannot be an empty [#227](https://github.com/icloud-photos-downloader/icloud_photos_downloader/issues/227)
 - fix: Warning for missing `tzinfo` in Docker image removed by adding `tzinfo`-package.
-  [#286](https://github.com/icloud-photos-downloader/icloud_photos_downloader/pull/286)
+[#286](https://github.com/icloud-photos-downloader/icloud_photos_downloader/pull/286)
 
 ## 1.7.1 (2020-11-15)
 
@@ -305,11 +305,11 @@
 
 - fix: --log-level option [#194](https://github.com/icloud-photos-downloader/icloud_photos_downloader/pull/194)
 - feature: Folder structure can be set to 'none' instead of a date pattern,
-  so all photos will be placed directly into the download directory.
+so all photos will be placed directly into the download directory.
 - fix: Empty directory structure being created #185
 - feature: removed multi-threaded downloading and added deprecation notice to --threads-num parameter #180, #188
 - fix: documentation issues, first addressed in #141 and separated contribution
-  info from README.md into CONTRIBUTING.md
+info from README.md into CONTRIBUTING.md
 
 ## 1.6.2 (2020-10-23)
 
@@ -318,7 +318,7 @@
 - fix: reduce chances of errors due to missing required parameters #175
 - fix: missing downloading process by upgrading tqdm dependency #167
 
----
+--------------------------------------------
 
 ## Earlier Versions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- feature: the obfuscated icloud email username is now included in the email about 2sa authentication failing, for when an installation is configured for multiple icloud accounts.
+- feature: the icloud email username is now included in the email about 2sa authentication failing, for when an installation is configured for multiple icloud accounts.
 
 ## 1.27.1 (2025-03-16)
 
@@ -77,7 +77,7 @@
 
 ## 1.23.0 (2024-07-25)
 
-- feature: update webui and allow to cancel and resume sync 
+- feature: update webui and allow to cancel and resume sync
 - deprecate linux 386 and arm v6 support
 - add linux musl builds
 
@@ -265,7 +265,7 @@
 
 ## 1.9.0 (2023-02-10)
 
-- fix: replace invalid chars in filenames with '_' [#378](https://github.com/icloud-photos-downloader/icloud_photos_downloader/issues/378)
+- fix: replace invalid chars in filenames with '\_' [#378](https://github.com/icloud-photos-downloader/icloud_photos_downloader/issues/378)
 - feature: add `--domain` parameter to support mainland China [#572](https://github.com/icloud-photos-downloader/icloud_photos_downloader/issues/572), [#545](https://github.com/icloud-photos-downloader/icloud_photos_downloader/issues/545)
 - feature: add `linux/arm/v7` and `linux/arm/v6` docker image [#434](https://github.com/icloud-photos-downloader/icloud_photos_downloader/issues/434)
 
@@ -290,7 +290,7 @@
 
 - fix: smtp server_hostname cannot be an empty [#227](https://github.com/icloud-photos-downloader/icloud_photos_downloader/issues/227)
 - fix: Warning for missing `tzinfo` in Docker image removed by adding `tzinfo`-package.
-[#286](https://github.com/icloud-photos-downloader/icloud_photos_downloader/pull/286)
+  [#286](https://github.com/icloud-photos-downloader/icloud_photos_downloader/pull/286)
 
 ## 1.7.1 (2020-11-15)
 
@@ -305,11 +305,11 @@
 
 - fix: --log-level option [#194](https://github.com/icloud-photos-downloader/icloud_photos_downloader/pull/194)
 - feature: Folder structure can be set to 'none' instead of a date pattern,
-so all photos will be placed directly into the download directory.
+  so all photos will be placed directly into the download directory.
 - fix: Empty directory structure being created #185
 - feature: removed multi-threaded downloading and added deprecation notice to --threads-num parameter #180, #188
 - fix: documentation issues, first addressed in #141 and separated contribution
-info from README.md into CONTRIBUTING.md
+  info from README.md into CONTRIBUTING.md
 
 ## 1.6.2 (2020-10-23)
 
@@ -318,7 +318,7 @@ info from README.md into CONTRIBUTING.md
 - fix: reduce chances of errors due to missing required parameters #175
 - fix: missing downloading process by upgrading tqdm dependency #167
 
---------------------------------------------
+---
 
 ## Earlier Versions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- feature: the obfuscated icloud email username is now included in the email about 2sa authentication failing, for when an installation is configured for multiple icloud accounts.
+
 ## 1.27.1 (2025-03-16)
 
 - fix: disambiguate whole photo collection from the album with `All Photos` name [#1077](https://github.com/icloud-photos-downloader/icloud_photos_downloader/issues/1077)

--- a/src/icloudpd/base.py
+++ b/src/icloudpd/base.py
@@ -1230,6 +1230,7 @@ def core(
         if smtp_username is not None or notification_email is not None:
             send_2sa_notification(
                 logger,
+                username,
                 smtp_username,
                 smtp_password,
                 smtp_host,

--- a/src/icloudpd/email_notifications.py
+++ b/src/icloudpd/email_notifications.py
@@ -6,8 +6,19 @@ import smtplib
 from typing import Optional, cast
 
 
+def obfuscate_email(email: str) -> str:
+    """Obfuscate the username bit of an email address, ie e***l@gmail.com"""
+    if "@" not in email:
+        return email  # Return as is if it's not a valid email
+    local_part, domain = email.split("@")
+    if len(local_part) <= 2:
+        return f"{local_part[0]}***@{domain}"
+    return f"{local_part[0]}***{local_part[-1]}@{domain}"
+
+
 def send_2sa_notification(
     logger: logging.Logger,
+    username: str,
     smtp_email: Optional[str],
     smtp_password: Optional[str],
     smtp_host: str,
@@ -38,9 +49,9 @@ def send_2sa_notification(
     subj = "icloud_photos_downloader: Two step authentication has expired"
     date = datetime.datetime.now().strftime("%d/%m/%Y %H:%M")
 
-    message_text = """Hello,
+    message_text = f"""Hello,
 
-Two-step authentication has expired for the icloud_photos_downloader script.
+{obfuscate_email(username)}'s two-step authentication has expired for the icloud_photos_downloader script.
 Please log in to your server and run the script manually to update two-step authentication."""
 
     msg = f"From: {from_addr}\n" + f"To: {to_addr}\nSubject: {subj}\nDate: {date}\n\n{message_text}"

--- a/src/icloudpd/email_notifications.py
+++ b/src/icloudpd/email_notifications.py
@@ -6,16 +6,6 @@ import smtplib
 from typing import Optional, cast
 
 
-def obfuscate_email(email: str) -> str:
-    """Obfuscate the username bit of an email address, ie e***l@gmail.com"""
-    if "@" not in email:
-        return email  # Return as is if it's not a valid email
-    local_part, domain = email.split("@")
-    if len(local_part) <= 2:
-        return f"{local_part[0]}***@{domain}"
-    return f"{local_part[0]}***{local_part[-1]}@{domain}"
-
-
 def send_2sa_notification(
     logger: logging.Logger,
     username: str,
@@ -51,10 +41,13 @@ def send_2sa_notification(
 
     message_text = f"""Hello,
 
-{obfuscate_email(username)}'s two-step authentication has expired for the icloud_photos_downloader script.
+{username}'s two-step authentication has expired for the icloud_photos_downloader script.
 Please log in to your server and run the script manually to update two-step authentication."""
 
-    msg = f"From: {from_addr}\n" + f"To: {to_addr}\nSubject: {subj}\nDate: {date}\n\n{message_text}"
+    msg = (
+        f"From: {from_addr}\n"
+        + f"To: {to_addr}\nSubject: {subj}\nDate: {date}\n\n{message_text}"
+    )
 
     smtp.sendmail(from_addr, to_addr, msg)
     smtp.quit()

--- a/tests/test_email_notifications.py
+++ b/tests/test_email_notifications.py
@@ -9,6 +9,7 @@ from freezegun import freeze_time
 from vcr import VCR
 
 from icloudpd.base import main
+from icloudpd.email_notifications import obfuscate_email
 from tests.helpers import path_from_project_root, recreate_path
 
 vcr = VCR(decode_compressed_response=True, record_mode="none")
@@ -67,7 +68,7 @@ class EmailNotificationsTestCase(TestCase):
                 "To: jdoe+notifications@gmail.com\n"
                 "Subject: icloud_photos_downloader: Two step authentication has expired\n"
                 "Date: 01/01/2018 00:00\n\nHello,\n\n"
-                "Two-step authentication has expired for the icloud_photos_downloader script.\n"
+                "j***e@gmail.com's two-step authentication has expired for the icloud_photos_downloader script.\n"
                 "Please log in to your server and run the script manually to update two-step "
                 "authentication.",
             )
@@ -114,7 +115,7 @@ class EmailNotificationsTestCase(TestCase):
                 "To: jdoe+notifications@gmail.com\n"
                 "Subject: icloud_photos_downloader: Two step authentication has expired\n"
                 "Date: 01/01/2018 00:00\n\nHello,\n\n"
-                "Two-step authentication has expired for the icloud_photos_downloader script.\n"
+                "j***e@gmail.com's two-step authentication has expired for the icloud_photos_downloader script.\n"
                 "Please log in to your server and run the script manually to update two-step "
                 "authentication.",
             )
@@ -198,7 +199,23 @@ class EmailNotificationsTestCase(TestCase):
                 "To: JD <jdoe+notifications@gmail.com>\n"
                 "Subject: icloud_photos_downloader: Two step authentication has expired\n"
                 "Date: 01/01/2018 00:00\n\nHello,\n\n"
-                "Two-step authentication has expired for the icloud_photos_downloader script.\n"
+                "j***e@gmail.com's two-step authentication has expired for the icloud_photos_downloader script.\n"
                 "Please log in to your server and run the script manually to update two-step "
                 "authentication.",
             )
+
+    def test_obsfucate_email(self) -> None:
+        # Test cases for valid email addresses
+        assert obfuscate_email("jdoe@gmail.com") == "j***e@gmail.com"
+        assert obfuscate_email("ab@gmail.com") == "a***@gmail.com"
+        assert obfuscate_email("a@gmail.com") == "a***@gmail.com"
+        assert obfuscate_email("john.doe@example.com") == "j***e@example.com"
+
+        # Test cases for invalid email addresses
+        assert obfuscate_email("not-an-email") == "not-an-email"
+        assert obfuscate_email("") == ""
+        assert obfuscate_email("plainaddress") == "plainaddress"
+
+        # Test cases for edge cases
+        assert obfuscate_email("a@b.com") == "a***@b.com"
+        assert obfuscate_email("ab@b.com") == "a***@b.com"

--- a/tests/test_email_notifications.py
+++ b/tests/test_email_notifications.py
@@ -9,7 +9,6 @@ from freezegun import freeze_time
 from vcr import VCR
 
 from icloudpd.base import main
-from icloudpd.email_notifications import obfuscate_email
 from tests.helpers import path_from_project_root, recreate_path
 
 vcr = VCR(decode_compressed_response=True, record_mode="none")
@@ -35,7 +34,9 @@ class EmailNotificationsTestCase(TestCase):
         with vcr.use_cassette(os.path.join(self.vcr_path, "auth_requires_2fa.yml")):
             with patch("smtplib.SMTP") as smtp:
                 # Pass fixed client ID via environment variable
-                runner = CliRunner(env={"CLIENT_ID": "EC5646DE-9423-11E8-BF21-14109FE0B321"})
+                runner = CliRunner(
+                    env={"CLIENT_ID": "EC5646DE-9423-11E8-BF21-14109FE0B321"}
+                )
                 result = runner.invoke(
                     main,
                     [
@@ -60,7 +61,9 @@ class EmailNotificationsTestCase(TestCase):
             smtp_instance = smtp()
             smtp_instance.connect.assert_called_once()
             smtp_instance.starttls.assert_called_once()
-            smtp_instance.login.assert_called_once_with("jdoe+smtp@gmail.com", "password1")
+            smtp_instance.login.assert_called_once_with(
+                "jdoe+smtp@gmail.com", "password1"
+            )
             smtp_instance.sendmail.assert_called_once_with(
                 "iCloud Photos Downloader <jdoe+smtp@gmail.com>",
                 "jdoe+notifications@gmail.com",
@@ -68,7 +71,7 @@ class EmailNotificationsTestCase(TestCase):
                 "To: jdoe+notifications@gmail.com\n"
                 "Subject: icloud_photos_downloader: Two step authentication has expired\n"
                 "Date: 01/01/2018 00:00\n\nHello,\n\n"
-                "j***e@gmail.com's two-step authentication has expired for the icloud_photos_downloader script.\n"
+                "jdoe@gmail.com's two-step authentication has expired for the icloud_photos_downloader script.\n"
                 "Please log in to your server and run the script manually to update two-step "
                 "authentication.",
             )
@@ -85,7 +88,9 @@ class EmailNotificationsTestCase(TestCase):
         with vcr.use_cassette(os.path.join(self.vcr_path, "auth_requires_2fa.yml")):
             with patch("smtplib.SMTP") as smtp:
                 # Pass fixed client ID via environment variable
-                runner = CliRunner(env={"CLIENT_ID": "EC5646DE-9423-11E8-BF21-14109FE0B321"})
+                runner = CliRunner(
+                    env={"CLIENT_ID": "EC5646DE-9423-11E8-BF21-14109FE0B321"}
+                )
                 result = runner.invoke(
                     main,
                     [
@@ -115,7 +120,7 @@ class EmailNotificationsTestCase(TestCase):
                 "To: jdoe+notifications@gmail.com\n"
                 "Subject: icloud_photos_downloader: Two step authentication has expired\n"
                 "Date: 01/01/2018 00:00\n\nHello,\n\n"
-                "j***e@gmail.com's two-step authentication has expired for the icloud_photos_downloader script.\n"
+                "jdoe@gmail.com's two-step authentication has expired for the icloud_photos_downloader script.\n"
                 "Please log in to your server and run the script manually to update two-step "
                 "authentication.",
             )
@@ -132,7 +137,9 @@ class EmailNotificationsTestCase(TestCase):
         with vcr.use_cassette(os.path.join(self.vcr_path, "auth_requires_2fa.yml")):
             with patch("subprocess.call") as subprocess_patched:
                 # Pass fixed client ID via environment variable
-                runner = CliRunner(env={"CLIENT_ID": "EC5646DE-9423-11E8-BF21-14109FE0B321"})
+                runner = CliRunner(
+                    env={"CLIENT_ID": "EC5646DE-9423-11E8-BF21-14109FE0B321"}
+                )
                 result = runner.invoke(
                     main,
                     [
@@ -164,7 +171,9 @@ class EmailNotificationsTestCase(TestCase):
         with vcr.use_cassette(os.path.join(self.vcr_path, "auth_requires_2fa.yml")):
             with patch("smtplib.SMTP") as smtp:
                 # Pass fixed client ID via environment variable
-                runner = CliRunner(env={"CLIENT_ID": "EC5646DE-9423-11E8-BF21-14109FE0B321"})
+                runner = CliRunner(
+                    env={"CLIENT_ID": "EC5646DE-9423-11E8-BF21-14109FE0B321"}
+                )
                 result = runner.invoke(
                     main,
                     [
@@ -191,7 +200,9 @@ class EmailNotificationsTestCase(TestCase):
             smtp_instance = smtp()
             smtp_instance.connect.assert_called_once()
             smtp_instance.starttls.assert_called_once()
-            smtp_instance.login.assert_called_once_with("jdoe+smtp@gmail.com", "password1")
+            smtp_instance.login.assert_called_once_with(
+                "jdoe+smtp@gmail.com", "password1"
+            )
             smtp_instance.sendmail.assert_called_once_with(
                 "JD <jdoe+notifications+from@gmail.com>",
                 "JD <jdoe+notifications@gmail.com>",
@@ -199,23 +210,7 @@ class EmailNotificationsTestCase(TestCase):
                 "To: JD <jdoe+notifications@gmail.com>\n"
                 "Subject: icloud_photos_downloader: Two step authentication has expired\n"
                 "Date: 01/01/2018 00:00\n\nHello,\n\n"
-                "j***e@gmail.com's two-step authentication has expired for the icloud_photos_downloader script.\n"
+                "jdoe@gmail.com's two-step authentication has expired for the icloud_photos_downloader script.\n"
                 "Please log in to your server and run the script manually to update two-step "
                 "authentication.",
             )
-
-    def test_obsfucate_email(self) -> None:
-        # Test cases for valid email addresses
-        assert obfuscate_email("jdoe@gmail.com") == "j***e@gmail.com"
-        assert obfuscate_email("ab@gmail.com") == "a***@gmail.com"
-        assert obfuscate_email("a@gmail.com") == "a***@gmail.com"
-        assert obfuscate_email("john.doe@example.com") == "j***e@example.com"
-
-        # Test cases for invalid email addresses
-        assert obfuscate_email("not-an-email") == "not-an-email"
-        assert obfuscate_email("") == ""
-        assert obfuscate_email("plainaddress") == "plainaddress"
-
-        # Test cases for edge cases
-        assert obfuscate_email("a@b.com") == "a***@b.com"
-        assert obfuscate_email("ab@b.com") == "a***@b.com"


### PR DESCRIPTION
I run icloudpd for multiple iCloud accounts and it's nicer to know which account needs 2fa redone in the email notification itself, rather than having to try and figure it out. This change just adds the email user in an obfuscated manner ie `a****w@icloud.com`:

```
Hello,

a****w@icloud.com's two-step authentication has expired for the icloud_photos_downloader script.
Please log in to your server and run the script manually to update two-step authentication.
```