### PR TITLE
fix ignored photos with --delete-after-download or --keep-icloud-recent-days

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix: fix ignored photos with --delete-after-download or --keep-icloud-recent-days [#616](https://github.com/icloud-photos-downloader/icloud_photos_downloader/issues/616)
+
 ## 1.27.4 (2025-04-15)
 
 - fix: broken pypi publishing [#1105](https://github.com/icloud-photos-downloader/icloud_photos_downloader/issues/1105)

--- a/src/icloudpd/base.py
+++ b/src/icloudpd/base.py
@@ -1403,6 +1403,8 @@ def core(
                         )
 
                         retrier(delete_local, error_handler)
+                        if photos.direction != "DESCENDING":
+                            photos.increment_offset(-1)
 
                     photos_counter += 1
                     status_exchange.get_progress().photos_counter = photos_counter

--- a/tests/test_download_photos.py
+++ b/tests/test_download_photos.py
@@ -491,7 +491,7 @@ class DownloadPhotoTestCase(TestCase):
     def test_handle_session_error_during_photo_iteration(self) -> None:
         base_dir = os.path.join(self.fixtures_path, inspect.stack()[0][3])
 
-        def mock_raise_response_error(_offset: int) -> NoReturn:
+        def mock_raise_response_error() -> NoReturn:
             raise PyiCloudAPIResponseException("Invalid global session", "100")
 
         with mock.patch("time.sleep") as sleep_mock:  # noqa: SIM117
@@ -1760,7 +1760,7 @@ class DownloadPhotoTestCase(TestCase):
     def test_handle_internal_error_during_photo_iteration(self) -> None:
         base_dir = os.path.join(self.fixtures_path, inspect.stack()[0][3])
 
-        def mock_raise_response_error(_offset: int) -> NoReturn:
+        def mock_raise_response_error() -> NoReturn:
             raise PyiCloudAPIResponseException("INTERNAL_ERROR", "INTERNAL_ERROR")
 
         with mock.patch("time.sleep") as sleep_mock:  # noqa: SIM117

--- a/tests/test_download_photos_id.py
+++ b/tests/test_download_photos_id.py
@@ -491,7 +491,7 @@ class DownloadPhotoNameIDTestCase(TestCase):
     def test_handle_session_error_during_photo_iteration_name_id7(self) -> None:
         base_dir = os.path.join(self.fixtures_path, inspect.stack()[0][3])
 
-        def mock_raise_response_error(_offset: int) -> NoReturn:
+        def mock_raise_response_error() -> NoReturn:
             raise PyiCloudAPIResponseException("Invalid global session", "100")
 
         with mock.patch("time.sleep") as sleep_mock:  # noqa: SIM117
@@ -1687,7 +1687,7 @@ class DownloadPhotoNameIDTestCase(TestCase):
     def test_handle_internal_error_during_photo_iteration_name_id7(self) -> None:
         base_dir = os.path.join(self.fixtures_path, inspect.stack()[0][3])
 
-        def mock_raise_response_error(_offset: int) -> NoReturn:
+        def mock_raise_response_error() -> NoReturn:
             raise PyiCloudAPIResponseException("INTERNAL_ERROR", "INTERNAL_ERROR")
 
         with mock.patch("time.sleep") as sleep_mock:  # noqa: SIM117


### PR DESCRIPTION
Fixes https://github.com/icloud-photos-downloader/icloud_photos_downloader/issues/616

Root cause discussed in https://github.com/icloud-photos-downloader/icloud_photos_downloader/issues/616#issuecomment-2732719121.