### PR TITLE
feat: retry on ConnectionResetError

### DIFF
--- a/src/icloudpd/download.py
+++ b/src/icloudpd/download.py
@@ -125,7 +125,7 @@ def download_media(
             )
             break
 
-        except (ConnectionError, socket.timeout, PyiCloudAPIResponseException, Timeout) as ex:
+        except (ConnectionError, ConnectionResetError, socket.timeout, PyiCloudAPIResponseException, Timeout) as ex:
             if "Invalid global session" in str(ex):
                 logger.error("Session error, re-authenticating...")
                 if retries > 0:

--- a/src/pyicloud_ipd/services/photos.py
+++ b/src/pyicloud_ipd/services/photos.py
@@ -410,7 +410,7 @@ class PhotoAlbum(object):
         while(True):
             try:
                 request = self.photos_request(offset)
-            except PyiCloudAPIResponseException as ex:
+            except (ConnectionError, ConnectionResetError, PyiCloudAPIResponseException) as ex:
                 if self.exception_handler:
                     exception_retries += 1
                     self.exception_handler(ex, exception_retries)


### PR DESCRIPTION
I am getting constant ConnectionReset errors on `photos_request`

```
  File "/Users/inigo/Programming/repos/public/icloud_photos_downloader/src/pyicloud_ipd/services/photos.py", line 412, in photos
    request = self.photos_request(offset)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/inigo/Programming/repos/public/icloud_photos_downloader/src/pyicloud_ipd/services/photos.py", line 392, in photos_request
    return self.service.session.post(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/inigo/Programming/repos/public/icloud_photos_downloader/.venv/lib/python3.12/site-packages/requests/sessions.py", line 637, in post
    return self.request("POST", url, data=data, json=json, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/inigo/Programming/repos/public/icloud_photos_downloader/src/pyicloud_ipd/session.py", line 67, in request
    response = super().request(method, url, **kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/inigo/Programming/repos/public/icloud_photos_downloader/.venv/lib/python3.12/site-packages/requests/sessions.py", line 589, in request
    resp = self.send(prep, **send_kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/inigo/Programming/repos/public/icloud_photos_downloader/.venv/lib/python3.12/site-packages/requests/sessions.py", line 703, in send
    r = adapter.send(request, **kwargs)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/inigo/Programming/repos/public/icloud_photos_downloader/.venv/lib/python3.12/site-packages/requests/adapters.py", line 682, in send
    raise ConnectionError(err, request=request)
requests.exceptions.ConnectionError: ('Connection aborted.', RemoteDisconnected('Remote end closed connection without response'))
```

but the failure is not caught by the except. Adding this correctly solves the issue on my end, one retry is sufficient for the error.