### PR TITLE
Adding iCloud Prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ We aim to release new versions once a week (Friday), if there is something worth
 
 ## iCloud Prerequisites
 
-In order to make iCloud Photo Downloader work, the iCloud account needs to be set up with the following settings. Otherwise the Apple Servers will return an `ACCESS_DENIED` error.
+To make iCloud Photo Downloader work, ensure the iCloud account is configured with the following settings, otherwise Apple Servers will return an ACCESS_DENIED error:
 
-- **Access iCloud Data on the Web:** On your iPhone / iPad, enable `Settings > Apple ID > iCloud > Access iCloud Data on the Web`
+- **Enable Access iCloud Data on the Web:** On your iPhone / iPad, enable `Settings > Apple ID > iCloud > Access iCloud Data on the Web`
 - **Disable Advanced Data Protection:** On your iPhone /iPad disable `Settings > Apple ID > iCloud > Advanced Data Protection`
 
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,14 @@ See [Documentation](https://icloud-photos-downloader.github.io/icloud_photos_dow
 
 We aim to release new versions once a week (Friday), if there is something worth delivering.
 
+## iCloud Prerequisites
+
+In order to make iCloud Photo Downloader work, the iCloud account needs to be set up with the following settings. Otherwise the Apple Servers will return an `ACCESS_DENIED` error.
+
+- **Access iCloud Data on the Web:** On your iPhone / iPad, enable `Settings > Apple ID > iCloud > Access iCloud Data on the Web`
+- **Disable Advanced Data Protection:** On your iPhone /iPad disable `Settings > Apple ID > iCloud > Advanced Data Protection`
+
+
 ## Install and Run
 
 There are three ways to run `icloudpd`:


### PR DESCRIPTION
For many users the `Access iCloud Data on the Web` might be disabled or the `Advanced Data Protection` might be enabled, which will cause `icloudpd` to fail with the following error:

`private db access disabled for this account.  Please wait a few minutes then try again.The remote servers might be trying to throttle requests. (ACCESS_DENIED)`

Please also see [This Git Issue](https://github.com/boredazfcuk/docker-icloudpd/issues/109) for reference.