### PR TITLE
Add support for environment variable config (#768)

### DIFF
--- a/src/icloudpd/base.py
+++ b/src/icloudpd/base.py
@@ -301,10 +301,13 @@ def report_version(ctx: click.Context, _param: click.Parameter, value: bool) -> 
 
 # Must import the constants object so that we can mock values in tests.
 
-CONTEXT_SETTINGS = {"help_option_names": ["-h", "--help"]}
+CONTEXT_SETTINGS = {
+    "help_option_names": ["-h", "--help"],
+    "auto_envvar_prefix": "ICLOUDPD",
+}
 
 
-@click.command(context_settings=CONTEXT_SETTINGS, options_metavar="<options>", no_args_is_help=True)
+@click.command(context_settings=CONTEXT_SETTINGS, options_metavar="<options>")
 @click.option(
     "-d",
     "--directory",


### PR DESCRIPTION
This adds support to configure iCloud PD using environment variables. 

The major benefit here is an easier configuration in e.g. containerized environments, where environment variables are much easier to handle and prevent the exposure of sensitive information through utilities such as `ps` or `top` from other users on the same system.

Caveat: to fully support env configuration, the click option `no_args_is_help` has been disabled. Otherwise, the user would have to specify at least one argument on the command line to allow every other variable to be taken from the environment. 

Happy to discuss this approach further. For example help could be shown if a certain set of required variables (username, directory, …) are not found in either env or args to ease user onboarding that way.