### PR TITLE
Adds SummaryTracker class and implements basic timer.

### DIFF
--- a/src/icloudpd/base.py
+++ b/src/icloudpd/base.py
@@ -1249,7 +1249,7 @@ def core(
 ) -> int:
     """Download all iCloud photos to a local directory"""
 
-    summary_tracker = SummaryTracker()
+    summary_tracker = SummaryTracker(logger)
 
     raise_error_on_2sa = (
         smtp_username is not None

--- a/src/icloudpd/summary.py
+++ b/src/icloudpd/summary.py
@@ -1,5 +1,6 @@
 """Tracks and prints a summary of actions performed"""
 
+import logging
 import time
 from datetime import timedelta
 
@@ -7,9 +8,10 @@ from datetime import timedelta
 class SummaryTracker:
     """Tracks and prints a summary of actions performed"""
 
-    def __init__(self) -> None:
+    def __init__(self, logger: logging.Logger) -> None:
         self.start_time = 0.0
         self.end_time = 0.0
+        self.logger = logger
 
     def start_timer(self) -> None:
         """Start the timer"""
@@ -22,6 +24,6 @@ class SummaryTracker:
     def print_summary(self) -> None:
         """Print the summary"""
         elapsed = self.end_time - self.start_time
-        print(f"\nExecution Summary")
-        print(f"=================")
-        print(f"Overall time: {timedelta(seconds=round(elapsed))}")
+        self.logger.info("\nExecution Summary")
+        self.logger.info("=================")
+        self.logger.info("Overall time: %s", timedelta(seconds=round(elapsed)))

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -2,19 +2,22 @@
 
 from unittest.mock import patch, Mock
 from icloudpd.summary import SummaryTracker
+from icloudpd.logger import setup_logger
 
 
 def test_prints_summary():
     """Test that the summary tracker prints the overall time"""
     with patch("time.time", side_effect=[1000.0, 1005.0]):
-        summary_tracker = SummaryTracker()
+        logger = setup_logger()
+        summary_tracker = SummaryTracker(logger)
         summary_tracker.start_timer()
         summary_tracker.stop_timer()
 
-        mock_stdout = Mock()
-        with patch("builtins.print", mock_stdout):
+        mock_logger_info = Mock()
+        with patch.object(logger, "info", mock_logger_info):
             summary_tracker.print_summary()
 
-        assert mock_stdout.call_args_list[0][0][0] == "\nExecution Summary"
-        assert mock_stdout.call_args_list[1][0][0] == "================="
-        assert "Overall time: 0:00:05" in mock_stdout.call_args_list[2][0][0]
+        assert mock_logger_info.call_args_list[0][0][0] == "\nExecution Summary"
+        assert mock_logger_info.call_args_list[1][0][0] == "================="
+        assert "Overall time:" in mock_logger_info.call_args_list[2][0][0]
+        assert mock_logger_info.call_args_list[2][0][1].seconds == 5


### PR DESCRIPTION
https://github.com/icloud-photos-downloader/icloud_photos_downloader/issues/183

This pull request introduces a new `SummaryTracker` class to track and summarize execution time for the `core` function. 
- This timer starts after authentication to avoid bloated time due to user input.
- Made in a way to extend to more summary metrics.

The changes include integrating the `SummaryTracker` into the `core` function, adding a timer mechanism, and creating unit tests to validate its functionality.

