### PR TITLE
split dev into dev and doc dependencies #1168

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -19,7 +19,7 @@ jobs:
     
     - name: Install Dev dependencies
       run: |
-        pip3 install --disable-pip-version-check -e .[dev]
+        pip3 install --disable-pip-version-check -e .[doc]
 
     - name: Build HTML
       run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,8 @@ dev = [
     "twine==6.1.0",
     "pyinstaller==6.14.0",
     "wheel==0.45.1",
+]
+doc = [
     "furo==2024.8.6",
     "Sphinx==7.4.7",
     "sphinx-autobuild==2024.10.3",


### PR DESCRIPTION
doc dependencies may not build cleanly on all platforms, so isolating them in their own dependency