### PR TITLE
add name-id7-versioned file match policy

### DIFF
--- a/src/icloudpd/base.py
+++ b/src/icloudpd/base.py
@@ -650,13 +650,20 @@ def download_builder(
 
         version = versions[download_size]
         photo_filename = filename_builder(photo)
+        filename_override = filename_overrides.get(download_size)
+
+        if file_match_policy == FileMatchPolicy.NAME_ID7_VERSIONED and download_size in (AssetVersionSize.ADJUSTED, AssetVersionSize.ALTERNATIVE):
+            ext = os.path.splitext(photo.calculate_version_filename(version, download_size, lp_filename_generator))[1]
+            stem = os.path.splitext(photo_filename)[0]
+            filename_override = f"{stem}-{download_size.value}{ext}"
+
         filename = calculate_version_filename(
             photo_filename,
             version,
             download_size,
             lp_filename_generator,
             photo.item_type,
-            filename_overrides.get(download_size),
+            filename_override,
         )
 
         download_path = local_download_path(filename, download_dir)

--- a/src/icloudpd/cli.py
+++ b/src/icloudpd/cli.py
@@ -235,8 +235,8 @@ def add_options_for_user(parser: argparse.ArgumentParser) -> argparse.ArgumentPa
     )
     cloned.add_argument(
         "--file-match-policy",
-        help="Policy to identify existing files and de-duplicate. `name-size-dedup-with-suffix` appends file size to de-duplicate. `name-id7` adds asset ID from iCloud to all filenames and does not de-duplicate. Default: %(default)s",
-        choices=["name-size-dedup-with-suffix", "name-id7"],
+        help="Policy to identify existing files and de-duplicate. `name-size-dedup-with-suffix` appends file size to de-duplicate. `name-id7` adds asset ID from iCloud to all filenames and does not de-duplicate. `name-id7-versioned` is similar to `name-id7`, but adds asset ID from iCloud even on `adjusted` and `alternative`. Default: %(default)s",
+        choices=["name-size-dedup-with-suffix", "name-id7", "name-id7-versioned"],
         default="name-size-dedup-with-suffix",
         type=lower,
     )

--- a/src/pyicloud_ipd/file_match.py
+++ b/src/pyicloud_ipd/file_match.py
@@ -4,6 +4,7 @@ from enum import Enum
 class FileMatchPolicy(Enum):
     NAME_SIZE_DEDUP_WITH_SUFFIX = "name-size-dedup-with-suffix"
     NAME_ID7 = "name-id7"
+    NAME_ID7_VERSIONED = "name-id7-versioned"
 
     def __str__(self) -> str:
         return self.name

--- a/src/pyicloud_ipd/services/photos.py
+++ b/src/pyicloud_ipd/services/photos.py
@@ -47,7 +47,7 @@ def apply_file_match_policy(
     """
 
     def transform_filename(filename: str) -> str:
-        if file_match_policy == FileMatchPolicy.NAME_ID7:
+        if file_match_policy in (FileMatchPolicy.NAME_ID7, FileMatchPolicy.NAME_ID7_VERSIONED):
             # Generate 7-character base64 suffix from asset ID
             id_suffix = base64.b64encode(asset_id.encode("utf-8")).decode("ascii")[0:7]
             return add_suffix_to_filename(f"_{id_suffix}", filename)


### PR DESCRIPTION
The existing `name-id7` file-match policy appends truncated iCloud asset ID to base filenames, but **not** to `adjusted` or `alternative` versions.

When multiple edited versions share the same original basename and are downloaded into the same folder, their filenames collide and only the first one is saved. Subsequent ones are skipped.

| Step | Original filename | Asset ID  | Resulting filename (adjusted) | Status                     |
| ---: | ----------------- | --------- | ----------------------------- | -------------------------- |
|    1 | `IMG_1234.JPG`    | `QVpTNGN` | `IMG_1234-adjusted.JPG`       | ✅ downloaded               |
|    2 | `IMG_1234.JPG`    | `QXpUOGx` | `IMG_1234-adjusted.JPG`       | ❌ skipped (already exists) |

So, because the ID isn’t carried into the adjusted/alternative filenames, different assets can produce the **same** adjusted filname.

## Proposal

Introduce a new policy, **`name-id7-versioned`**, which behaves like `name-id7` but **also** carries the truncated asset ID into `adjusted` and `alternative` versions.

| Step | Original filename | Asset ID  | Resulting filename (adjusted)   | Status       |
| ---: | ----------------- | --------- | ------------------------------- | ------------ |
|    1 | `IMG_1234.JPG`    | `QVpTNGN` | `IMG_1234_QVpTNGN-adjusted.JPG` | ✅ downloaded |
|    2 | `IMG_1234.JPG`    | `QXpUOGx` | `IMG_1234_QXpUOGx-adjusted.JPG` | ✅ downloaded |

> Likewise for `alternative`.

This new behavior can be selected with `--file-match-policy name-id7-versioned`.

## Benefits

* Prevents filename collisions for edited versions.
* Preserves a clear mapping between originals and their edited versions.
* Safer for syncing/backup pipelines that rely on unique filenames.

## Backward compatibility

* Default behavior is unchanged.
* Existing policies (`name-size-dedup-with-suffix`, `name-id7`) continue to work as before.
