### PR TITLE
fix: invalid field breaks compression

### DIFF
--- a/tests/test_xmp_sidecar.py
+++ b/tests/test_xmp_sidecar.py
@@ -74,6 +74,27 @@ class BuildXMPMetadata(TestCase):
         metadata = build_metadata(assetRecordStub)
         assert metadata.Orientation is None
 
+        # - a zlib compressed JSON without "metadata" key (lines 101-113 coverage)
+        assetRecordStub["fields"]["adjustmentSimpleDataEnc"]["value"] = (
+            "q1Yqzs9N9S/JSC3yTq1UslJQKkvMKU1VqgUA"
+        )
+        metadata = build_metadata(assetRecordStub)
+        assert metadata.Orientation is None
+
+        # - a zlib compressed JSON with "metadata" key but no "orientation" key (lines 101-113 coverage)
+        assetRecordStub["fields"]["adjustmentSimpleDataEnc"]["value"] = (
+            "q1bKTS1JTEksSVSyUqhWKs7PTfUvyUgt8k6tBAoolSXmlKYq1dYCAA=="
+        )
+        metadata = build_metadata(assetRecordStub)
+        assert metadata.Orientation is None
+
+        # - invalid data that fails decompression (lines 101-113 coverage)
+        assetRecordStub["fields"]["adjustmentSimpleDataEnc"]["value"] = (
+            "aW52YWxpZCBkYXRhIHRoYXQgd2lsbCBmYWlsIGRlY29tcHJlc3Npb24="
+        )
+        metadata = build_metadata(assetRecordStub)
+        assert metadata.Orientation is None
+
         # Test Screenshot Tagging
         assetRecordStub["fields"]["assetSubtypeV2"]["value"] = 3
         metadata = build_metadata(assetRecordStub)


### PR DESCRIPTION
Fixes:  #1063

Hi this is my first PR here so useful hints are appreciated.

I followed the contribution guidelines and added tests run the linters and type checkers.


## What have I done

- adds a failsafe function to prevent any further problems while decompressing the field

## Why have I done it

- a new field content for the adjustmentSimpleDataEnc field `johuAQAAAAAKXQAA` is breaking the decompression


