### PR TITLE
Fix 2fa email notification date header format

### DIFF
--- a/src/icloudpd/email_notifications.py
+++ b/src/icloudpd/email_notifications.py
@@ -37,7 +37,7 @@ def send_2sa_notification(
         smtp.login(smtp_email, smtp_password)
 
     subj = "icloud_photos_downloader: Two step authentication has expired"
-    date = datetime.datetime.now().strftime("%d/%m/%Y %H:%M")
+    date = datetime.datetime.now().strftime("%a, %d %b %Y %H:%M:%S %z")
 
     message_text = f"""Hello,
 


### PR DESCRIPTION
Current date format used in the 2fa email notice header is not [RFC 5322](https://www.rfc-editor.org/rfc/rfc5322#section-3.3) compliant and, in the case of Thunderbird, causes month and day to be swapped when sorting email by date e.g. 5th Jan becomes 1st of May