### PR TITLE
feat: add Prometheus and StatsD metrics support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- feat: add Prometheus and StatsD metrics support (`--metrics-backend` option)
+
 ## 1.32.2 (2025-09-01)
 
 - fix: HTTP response content not captured for authentication and non-streaming requests [#1240](https://github.com/icloud-photos-downloader/icloud_photos_downloader/issues/1240)

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ COPY dist/icloudpd-*.*.*-linux-musl-arm32v7 icloudpd
 FROM runtime_${TARGETARCH}_${TARGETVARIANT:-none} AS runtime
 ENV TZ=UTC
 EXPOSE 8080
+EXPOSE 9090
 WORKDIR /app
 RUN chmod +x /app/icloud /app/icloudpd
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ See [Documentation](https://icloud-photos-downloader.github.io/icloud_photos_dow
 - One time download and an option to monitor for iCloud changes continuously (`--watch-with-interval` option)
 - Optimizations for incremental runs (`--until-found` and `--recent` options)
 - Photo metadata (EXIF) updates (`--set-exif-datetime` option)
+- Prometheus and StatsD metrics for monitoring (`--metrics-backend` option)
 - ... and many more (use `--help` option to get full list)
 
 <!-- end features -->

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,6 +15,7 @@ naming
 mode
 size
 raw
+metrics
 webui
 nas
 reference

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,0 +1,196 @@
+# Metrics
+
+```{versionadded} 1.33.0
+```
+
+`icloudpd` supports exporting metrics for monitoring and observability. Two backends are supported: **Prometheus** and **StatsD**.
+
+## Configuration
+
+Enable metrics using the [`--metrics-backend`](metrics-backend-parameter) parameter:
+
+```bash
+# Prometheus only
+icloudpd --username user@example.com --directory /photos --metrics-backend prometheus
+
+# StatsD only
+icloudpd --username user@example.com --directory /photos --metrics-backend statsd
+
+# Both backends simultaneously
+icloudpd --username user@example.com --directory /photos --metrics-backend both
+```
+
+## Prometheus
+
+When using the `prometheus` backend, an HTTP server is started that exposes metrics at the `/metrics` endpoint in Prometheus exposition format.
+
+### Configuration Options
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| [`--prometheus-host`](prometheus-host-parameter) | `0.0.0.0` | Host to bind the HTTP server |
+| [`--prometheus-port`](prometheus-port-parameter) | `9090` | Port for the HTTP server |
+
+### Example Scrape Configuration
+
+Add the following to your Prometheus `prometheus.yml`:
+
+```yaml
+scrape_configs:
+  - job_name: 'icloudpd'
+    static_configs:
+      - targets: ['localhost:9090']
+```
+
+For Docker deployments:
+
+```yaml
+scrape_configs:
+  - job_name: 'icloudpd'
+    static_configs:
+      - targets: ['icloudpd:9090']
+```
+
+### Docker Usage
+
+When running icloudpd in Docker with Prometheus metrics, expose port 9090:
+
+```bash
+docker run -p 9090:9090 \
+    -v /path/to/photos:/data \
+    -v /path/to/cookies:/cookies \
+    icloudpd/icloudpd icloudpd \
+    --username user@example.com \
+    --directory /data \
+    --cookie-directory /cookies \
+    --metrics-backend prometheus \
+    --prometheus-host 0.0.0.0
+```
+
+## StatsD
+
+When using the `statsd` backend, metrics are pushed via UDP to a StatsD server. This is useful for integration with Graphite, Datadog, or other StatsD-compatible systems.
+
+### Configuration Options
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| [`--statsd-host`](statsd-host-parameter) | `localhost` | StatsD server host |
+| [`--statsd-port`](statsd-port-parameter) | `8125` | StatsD server port |
+| [`--statsd-prefix`](statsd-prefix-parameter) | `icloudpd` | Prefix for all metric names |
+
+### Example
+
+```bash
+icloudpd --username user@example.com --directory /photos \
+    --metrics-backend statsd \
+    --statsd-host statsd.example.com \
+    --statsd-port 8125 \
+    --statsd-prefix myapp.icloudpd
+```
+
+## Available Metrics
+
+### Counters
+
+| Metric | Labels | Description |
+|--------|--------|-------------|
+| `downloads_total` | `status`, `size` | Total number of download attempts. Status is `success` or `failure`. Size indicates the asset size variant. |
+| `download_bytes_total` | `size` | Total bytes downloaded successfully |
+| `download_retries_total` | `reason` | Number of download retries. Reason: `session`, `throttle`, or `io` |
+| `photos_processed_total` | `action` | Photos processed. Action: `downloaded`, `skipped`, or `deleted` |
+| `videos_processed_total` | `action` | Videos processed. Action: `downloaded`, `skipped`, or `deleted` |
+| `sync_runs_total` | `status` | Sync run completions. Status: `success`, `failure`, or `cancelled` |
+| `api_requests_total` | `method`, `status_code` | Total API requests to iCloud |
+| `api_errors_total` | `error_type` | API errors by type |
+| `auth_attempts_total` | `result`, `method` | Authentication attempts. Result: `started`, `success`, `failure`. Method: `password`, `2fa`, `2sa`, `2fa_web` |
+| `auth_mfa_requests_total` | `type` | MFA code requests. Type: `2fa` or `2sa` |
+
+### Gauges
+
+| Metric | Labels | Description |
+|--------|--------|-------------|
+| `up` | - | Set to 1 when icloudpd is running |
+| `current_progress` | - | Current sync progress percentage (0-100) |
+
+### Histograms
+
+| Metric | Labels | Description |
+|--------|--------|-------------|
+| `download_duration_seconds` | `size` | Time taken to download individual files |
+| `sync_duration_seconds` | - | Total duration of each sync run |
+| `api_request_duration_seconds` | `method` | Duration of individual API requests |
+
+## Multi-Instance Setup
+
+When running multiple `icloudpd` instances (e.g., for different iCloud accounts), use the [`--metrics-instance`](metrics-instance-parameter) parameter to distinguish them:
+
+```bash
+# Instance for user1
+icloudpd --username user1@example.com --directory /photos/user1 \
+    --metrics-backend prometheus --prometheus-port 9091 \
+    --metrics-instance user1
+
+# Instance for user2
+icloudpd --username user2@example.com --directory /photos/user2 \
+    --metrics-backend prometheus --prometheus-port 9092 \
+    --metrics-instance user2
+```
+
+The instance label is added to all metrics, allowing you to filter and aggregate by instance in your monitoring system.
+
+## Example Queries
+
+### Prometheus/PromQL
+
+Download success rate:
+```promql
+sum(rate(downloads_total{status="success"}[5m])) / sum(rate(downloads_total[5m]))
+```
+
+Photos downloaded per hour:
+```promql
+sum(increase(photos_processed_total{action="downloaded"}[1h]))
+```
+
+Videos downloaded per hour:
+```promql
+sum(increase(videos_processed_total{action="downloaded"}[1h]))
+```
+
+Total assets (photos + videos) downloaded per hour:
+```promql
+sum(increase(photos_processed_total{action="downloaded"}[1h])) + sum(increase(videos_processed_total{action="downloaded"}[1h]))
+```
+
+Average download duration:
+```promql
+rate(download_duration_seconds_sum[5m]) / rate(download_duration_seconds_count[5m])
+```
+
+API error rate by type:
+```promql
+sum by (error_type) (rate(api_errors_total[5m]))
+```
+
+Sync success rate:
+```promql
+sum(rate(sync_runs_total{status="success"}[24h])) / sum(rate(sync_runs_total[24h]))
+```
+
+### Grafana Dashboard
+
+An example Grafana dashboard is available at [`examples/grafana-dashboard.json`](https://github.com/icloud-photos-downloader/icloud_photos_downloader/blob/master/examples/grafana-dashboard.json). Import it into Grafana to get started quickly.
+
+The dashboard includes:
+- Status overview (up/down, sync runs, avg duration)
+- Photos and videos processed (total and rate)
+- Sync activity charts
+- API requests and auth attempts
+
+### Grafana Dashboard Tips
+
+- Use `up` metric for availability alerting
+- Track `current_progress` for real-time sync status
+- Alert on `api_errors_total` increases for early warning of issues
+- Use `sync_duration_seconds` histograms to track performance trends

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -374,3 +374,71 @@ This is a list of all options available for the command line interface (CLI) of 
     ```{note}
     The date is when the asset was created, not when it was added to iCloud.
     ```
+
+(metrics-backend-parameter)=
+`--metrics-backend X`
+
+:   Specifies the metrics backend to use for observability. Available options: `none` (default), `prometheus`, `statsd`, or `both`.
+
+    When set to `prometheus`, an HTTP server is started that exposes metrics at `/metrics`.
+    When set to `statsd`, metrics are pushed via UDP to a StatsD server.
+    When set to `both`, both backends are enabled simultaneously.
+
+    ```{versionadded} 1.33.0
+    ```
+
+    ```{seealso}
+    Details on [Metrics](metrics)
+    ```
+
+(prometheus-port-parameter)=
+`--prometheus-port X`
+
+:   Port for the Prometheus metrics HTTP server. Default: 9090.
+
+    ```{versionadded} 1.33.0
+    ```
+
+(prometheus-host-parameter)=
+`--prometheus-host X`
+
+:   Host to bind the Prometheus metrics HTTP server. Default: 0.0.0.0.
+
+    ```{versionadded} 1.33.0
+    ```
+
+(statsd-host-parameter)=
+`--statsd-host X`
+
+:   StatsD server host. Default: localhost.
+
+    ```{versionadded} 1.33.0
+    ```
+
+(statsd-port-parameter)=
+`--statsd-port X`
+
+:   StatsD server port. Default: 8125.
+
+    ```{versionadded} 1.33.0
+    ```
+
+(statsd-prefix-parameter)=
+`--statsd-prefix X`
+
+:   Prefix for StatsD metric names. Default: icloudpd.
+
+    ```{versionadded} 1.33.0
+    ```
+
+(metrics-instance-parameter)=
+`--metrics-instance X`
+
+:   Instance label to add to all metrics for identifying this icloudpd instance. Useful when running multiple instances (e.g., for different users).
+
+    ```{versionadded} 1.33.0
+    ```
+
+    ```{seealso}
+    Details on [Metrics](metrics)
+    ```

--- a/examples/grafana-dashboard.json
+++ b/examples/grafana-dashboard.json
@@ -1,0 +1,1336 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_GRAFANACLOUD-PROM",
+      "label": "prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__elements": {},
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "12.4.0-21428475782"
+    },
+    {
+      "type": "panel",
+      "id": "piechart",
+      "name": "Pie chart",
+      "version": ""
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "stat",
+      "name": "Stat",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Metrics for https://github.com/icloud-photos-downloader/icloud_photos_downloader",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "panels": [],
+      "title": "Status",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "color": "red",
+                  "index": 1,
+                  "text": "Down"
+                },
+                "1": {
+                  "color": "green",
+                  "index": 0,
+                  "text": "Up"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": 0
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 0,
+        "y": 1
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.0-21428475782",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "icloudpd_up{job=\"icloudpd\", instance=~\"$instance\"}",
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "title": "icloudpd Status",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            }
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 5,
+        "x": 4,
+        "y": 1
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "right",
+          "showLegend": true
+        },
+        "pieType": "pie",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "sort": "desc",
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.0-21428475782",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (status,instance) (icloudpd_sync_runs_total{job=\"icloudpd\", instance=~\"$instance\"})",
+          "legendFormat": "{{instance}} - {{status}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Total Sync Runs by Status",
+      "type": "piechart"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 9,
+        "y": 1
+      },
+      "id": 5,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.0-21428475782",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (instance) (icloudpd_sync_duration_seconds_sum{job=\"icloudpd\", instance=~\"$instance\"}) / sum by (instance) (icloudpd_sync_duration_seconds_count{job=\"icloudpd\", instance=~\"$instance\"})",
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Avg Sync Duration",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 15,
+        "y": 1
+      },
+      "id": 16,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.0-21428475782",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (instance) (icloudpd_videos_processed_total{job=\"icloudpd\", instance=~\"$instance\", action=\"downloaded\"}) OR on() vector(0)",
+          "legendFormat": "{{instance}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Total Videos Downloaded",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 5,
+        "x": 19,
+        "y": 1
+      },
+      "id": 15,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.0-21428475782",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (instance) (icloudpd_photos_processed_total{job=\"icloudpd\", instance=~\"$instance\", action=\"downloaded\"}) OR on() vector(0)",
+          "legendFormat": "{{instance}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Total Photos Downloaded",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 5
+      },
+      "id": 6,
+      "panels": [],
+      "title": "Photos",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 6
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.0-21428475782",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (instance, action) (icloudpd_photos_processed_total{job=\"icloudpd\", instance=~\"$instance\"})",
+          "legendFormat": "{{instance}} - {{action}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Photos Processed (Total)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "bars",
+            "fillOpacity": 100,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 6
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.0-21428475782",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (instance) (increase(icloudpd_photos_processed_total{job=\"icloudpd\", instance=~\"$instance\", action=\"downloaded\"}[$__rate_interval])) OR on() vector(0)",
+          "legendFormat": "{{instance}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Photos Downloaded (Rate)",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 14
+      },
+      "id": 17,
+      "panels": [],
+      "title": "Videos",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 15
+      },
+      "id": 18,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.0-21428475782",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (instance, action) (icloudpd_videos_processed_total{job=\"icloudpd\", instance=~\"$instance\"}) OR on() vector(0)",
+          "legendFormat": "{{instance}} - {{action}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Videos Processed (Total)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "bars",
+            "fillOpacity": 100,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 15
+      },
+      "id": 19,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.0-21428475782",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (instance) (increase(icloudpd_videos_processed_total{job=\"icloudpd\", instance=~\"$instance\", action=\"downloaded\"}[$__rate_interval])) OR on() vector(0)",
+          "legendFormat": "{{instance}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Videos Downloaded (Rate)",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 23
+      },
+      "id": 9,
+      "panels": [],
+      "title": "Sync Activity",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 24
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.0-21428475782",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (instance, status) (icloudpd_sync_runs_total{job=\"icloudpd\", instance=~\"$instance\"})",
+          "legendFormat": "{{instance}} - {{status}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Sync Runs by Instance & Status",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 24
+      },
+      "id": 11,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.0-21428475782",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.95, sum by (instance, le) (rate(icloudpd_sync_duration_seconds_bucket{job=\"icloudpd\", instance=~\"$instance\"}[$__rate_interval])))",
+          "legendFormat": "{{instance}} p95",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.50, sum by (instance, le) (rate(icloudpd_sync_duration_seconds_bucket{job=\"icloudpd\", instance=~\"$instance\"}[$__rate_interval])))",
+          "legendFormat": "{{instance}} p50",
+          "refId": "B"
+        }
+      ],
+      "title": "Sync Duration",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 32
+      },
+      "id": 12,
+      "panels": [],
+      "title": "API & Auth",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 33
+      },
+      "id": 13,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.0-21428475782",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (instance, status_code) (icloudpd_api_requests_total{job=\"icloudpd\", instance=~\"$instance\"})",
+          "legendFormat": "{{instance}} - {{status_code}}",
+          "refId": "A"
+        }
+      ],
+      "title": "API Requests by Status",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 33
+      },
+      "id": 14,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.0-21428475782",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (instance, result) (icloudpd_auth_attempts_total{job=\"icloudpd\", instance=~\"$instance\"})",
+          "legendFormat": "{{instance}} - {{result}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Auth Attempts by Result",
+      "type": "timeseries"
+    }
+  ],
+  "preload": false,
+  "refresh": "1m",
+  "schemaVersion": 42,
+  "tags": [
+    "icloudpd",
+    "photos"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "text": "",
+          "value": "${DS_GRAFANACLOUD-PROM}",
+          "selected": true
+        },
+        "includeAll": false,
+        "label": "Data Source",
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(icloudpd_up{job=\"icloudpd\"}, instance)",
+        "includeAll": true,
+        "label": "Instance",
+        "multi": true,
+        "name": "instance",
+        "options": [],
+        "query": {
+          "query": "label_values(icloudpd_up{job=\"icloudpd\"}, instance)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "regexApplyTo": "value",
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "iCloud Photo Downloader",
+  "uid": "icloudpd-dashboard",
+  "version": 8,
+  "weekStart": "",
+  "id": null
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,9 @@ dependencies = [
     "keyring==25.6.0",
     "keyrings-alt==5.0.2",
     "srp==1.0.22",
+    # metrics
+    "prometheus_client>=0.20.0",
+    "statsd>=4.0.1",
 ]
 
 [dependency-groups]

--- a/src/icloudpd/authentication.py
+++ b/src/icloudpd/authentication.py
@@ -6,6 +6,7 @@ import time
 from functools import partial
 from typing import Any, Callable, Dict, List, Mapping, Tuple
 
+from icloudpd.metrics import MetricsCollector, NoOpCollector
 from icloudpd.mfa_provider import MFAProvider
 from icloudpd.status import Status, StatusExchange
 from pyicloud_ipd.base import PyiCloudService
@@ -69,9 +70,14 @@ def authenticator(
     response_observer: Callable[[Mapping[str, Any]], None] | None = None,
     cookie_directory: str | None = None,
     client_id: str | None = None,
+    metrics: MetricsCollector | None = None,
 ) -> PyiCloudService:
     """Authenticate with iCloud username and password"""
     logger.debug("Authenticating...")
+
+    if metrics is None:
+        metrics = NoOpCollector()
+
     valid_password: List[str] = []
 
     def password_provider(username: str, valid_password: List[str]) -> str | None:
@@ -83,6 +89,9 @@ def authenticator(
                 return password
         return None
 
+    # Track auth attempt
+    metrics.inc("auth_attempts_total", labels={"result": "started", "method": "password"})
+
     icloud = PyiCloudService(
         domain,
         username,
@@ -90,9 +99,11 @@ def authenticator(
         response_observer,
         cookie_directory=cookie_directory,
         client_id=client_id,
+        metrics=metrics,
     )
 
     if not icloud:
+        metrics.inc("auth_attempts_total", labels={"result": "failure", "method": "password"})
         raise NotImplementedError("None of providers gave password")
 
     if valid_password:
@@ -103,22 +114,32 @@ def authenticator(
 
     if icloud.requires_2fa:
         logger.info("Two-factor authentication is required (2fa)")
+        metrics.inc("auth_mfa_requests_total", labels={"type": "2fa"})
         notificator()
         if mfa_provider == MFAProvider.WEBUI:
-            request_2fa_web(icloud, logger, status_exchange)
+            request_2fa_web(icloud, logger, status_exchange, metrics)
         else:
-            request_2fa(icloud, logger)
+            request_2fa(icloud, logger, metrics)
 
     elif icloud.requires_2sa:
         logger.info("Two-step authentication is required (2sa)")
+        metrics.inc("auth_mfa_requests_total", labels={"type": "2sa"})
         notificator()
-        request_2sa(icloud, logger)
+        request_2sa(icloud, logger, metrics)
+    else:
+        # Successful auth without MFA
+        metrics.inc("auth_attempts_total", labels={"result": "success", "method": "password"})
 
     return icloud
 
 
-def request_2sa(icloud: PyiCloudService, logger: logging.Logger) -> None:
+def request_2sa(
+    icloud: PyiCloudService, logger: logging.Logger, metrics: MetricsCollector | None = None
+) -> None:
     """Request two-step authentication. Prompts for SMS or device"""
+    if metrics is None:
+        metrics = NoOpCollector()
+
     devices = icloud.trusted_devices
     devices_count = len(devices)
     device_index: int = 0
@@ -134,12 +155,15 @@ def request_2sa(icloud: PyiCloudService, logger: logging.Logger) -> None:
     device = devices[device_index]
     if not icloud.send_verification_code(device):
         logger.error("Failed to send two-step authentication code")
+        metrics.inc("auth_attempts_total", labels={"result": "failure", "method": "2sa"})
         sys.exit(1)
 
     code = prompt_string("Please enter two-step authentication code")
     if not icloud.validate_verification_code(device, code):
         logger.error("Failed to verify two-step authentication code")
+        metrics.inc("auth_attempts_total", labels={"result": "failure", "method": "2sa"})
         sys.exit(1)
+    metrics.inc("auth_attempts_total", labels={"result": "success", "method": "2sa"})
     logger.info(
         "Great, you're all set up. The script can now be run without "
         "user interaction until 2SA expires.\n"
@@ -149,13 +173,19 @@ def request_2sa(icloud: PyiCloudService, logger: logging.Logger) -> None:
     )
 
 
-def request_2fa(icloud: PyiCloudService, logger: logging.Logger) -> None:
+def request_2fa(
+    icloud: PyiCloudService, logger: logging.Logger, metrics: MetricsCollector | None = None
+) -> None:
     """Request two-factor authentication."""
+    if metrics is None:
+        metrics = NoOpCollector()
+
     devices = icloud.get_trusted_phone_numbers()
     devices_count = len(devices)
     device_index_alphabet = "abcdefghijklmnopqrstuvwxyz"
     if devices_count > 0:
         if devices_count > len(device_index_alphabet):
+            metrics.inc("auth_attempts_total", labels={"result": "failure", "method": "2fa"})
             raise PyiCloudFailedMFAException("Too many trusted devices for authentication")
 
         for i, device in enumerate(devices):
@@ -200,6 +230,7 @@ def request_2fa(icloud: PyiCloudService, logger: logging.Logger) -> None:
             device_index = device_index_alphabet.index(index_or_code)
             device = devices[device_index]
             if not icloud.send_2fa_code_sms(device.id):
+                metrics.inc("auth_attempts_total", labels={"result": "failure", "method": "2fa"})
                 raise PyiCloudFailedMFAException("Failed to send two-factor authentication code")
             while True:
                 from foundation.string_utils import strip
@@ -214,9 +245,11 @@ def request_2fa(icloud: PyiCloudService, logger: logging.Logger) -> None:
                 echo("Invalid code, should be six digits. Try again")
 
             if not icloud.validate_2fa_code_sms(device.id, code):
+                metrics.inc("auth_attempts_total", labels={"result": "failure", "method": "2fa"})
                 raise PyiCloudFailedMFAException("Failed to verify two-factor authentication code")
         else:
             if not icloud.validate_2fa_code(index_or_code):
+                metrics.inc("auth_attempts_total", labels={"result": "failure", "method": "2fa"})
                 raise PyiCloudFailedMFAException("Failed to verify two-factor authentication code")
     else:
         while True:
@@ -227,7 +260,9 @@ def request_2fa(icloud: PyiCloudService, logger: logging.Logger) -> None:
                 break
             echo("Invalid code, should be six digits. Try again")
         if not icloud.validate_2fa_code(code):
+            metrics.inc("auth_attempts_total", labels={"result": "failure", "method": "2fa"})
             raise PyiCloudFailedMFAException("Failed to verify two-factor authentication code")
+    metrics.inc("auth_attempts_total", labels={"result": "success", "method": "2fa"})
     logger.info(
         "Great, you're all set up. The script can now be run without "
         "user interaction until 2FA expires.\n"
@@ -238,10 +273,17 @@ def request_2fa(icloud: PyiCloudService, logger: logging.Logger) -> None:
 
 
 def request_2fa_web(
-    icloud: PyiCloudService, logger: logging.Logger, status_exchange: StatusExchange
+    icloud: PyiCloudService,
+    logger: logging.Logger,
+    status_exchange: StatusExchange,
+    metrics: MetricsCollector | None = None,
 ) -> None:
     """Request two-factor authentication through Webui."""
+    if metrics is None:
+        metrics = NoOpCollector()
+
     if not status_exchange.replace_status(Status.NO_INPUT_NEEDED, Status.NEED_MFA):
+        metrics.inc("auth_attempts_total", labels={"result": "failure", "method": "2fa_web"})
         raise PyiCloudFailedMFAException(
             f"Expected NO_INPUT_NEEDED, but got {status_exchange.get_status()}"
         )
@@ -258,6 +300,9 @@ def request_2fa_web(
         if status_exchange.replace_status(Status.SUPPLIED_MFA, Status.CHECKING_MFA):
             code = status_exchange.get_payload()
             if not code:
+                metrics.inc(
+                    "auth_attempts_total", labels={"result": "failure", "method": "2fa_web"}
+                )
                 raise PyiCloudFailedMFAException(
                     "Internal error: did not get code for SUPPLIED_MFA status"
                 )
@@ -268,9 +313,15 @@ def request_2fa_web(
                     # TODO give user an option to restart auth in case they missed code
                     continue
                 else:
+                    metrics.inc(
+                        "auth_attempts_total", labels={"result": "failure", "method": "2fa_web"}
+                    )
                     raise PyiCloudFailedMFAException("Failed to chage status of invalid code")
             else:
                 status_exchange.replace_status(Status.CHECKING_MFA, Status.NO_INPUT_NEEDED)  # done
+                metrics.inc(
+                    "auth_attempts_total", labels={"result": "success", "method": "2fa_web"}
+                )
 
                 logger.info(
                     "Great, you're all set up. The script can now be run without "
@@ -280,4 +331,5 @@ def request_2fa_web(
                     "(Use --help to view information about SMTP options.)"
                 )
         else:
+            metrics.inc("auth_attempts_total", labels={"result": "failure", "method": "2fa_web"})
             raise PyiCloudFailedMFAException("Failed to change status")

--- a/src/icloudpd/base.py
+++ b/src/icloudpd/base.py
@@ -41,11 +41,12 @@ from foundation.core import compose, identity, map_, partial_1_1
 from icloudpd import download, exif_datetime
 from icloudpd.authentication import authenticator
 from icloudpd.autodelete import autodelete_photos
-from icloudpd.config import GlobalConfig, UserConfig
+from icloudpd.config import GlobalConfig, MetricsBackend, UserConfig
 from icloudpd.counter import Counter
 from icloudpd.email_notifications import send_2sa_notification
 from icloudpd.filename_policies import build_filename_with_policies, create_filename_builder
 from icloudpd.log_level import LogLevel
+from icloudpd.metrics import MetricsCollector, create_metrics_collector
 from icloudpd.mfa_provider import MFAProvider
 from icloudpd.password_provider import PasswordProvider
 from icloudpd.paths import local_download_path, remove_unicode_chars
@@ -239,6 +240,24 @@ def run_with_configs(global_config: GlobalConfig, user_configs: Sequence[UserCon
     # Create shared logger
     logger = create_logger(global_config)
 
+    # Create metrics collector based on configuration
+    metrics = create_metrics_collector(
+        backend=global_config.metrics.backend.value,
+        prometheus_host=global_config.metrics.prometheus_host,
+        prometheus_port=global_config.metrics.prometheus_port,
+        statsd_host=global_config.metrics.statsd_host,
+        statsd_port=global_config.metrics.statsd_port,
+        statsd_prefix=global_config.metrics.statsd_prefix,
+        instance=global_config.metrics.instance,
+    )
+
+    # Start metrics server if using Prometheus
+    if global_config.metrics.backend in (MetricsBackend.PROMETHEUS, MetricsBackend.BOTH):
+        metrics.start_server()
+
+    # Set up gauge to indicate the service is running
+    metrics.set("up", 1)
+
     # Create shared status exchange for web server and progress tracking
     shared_status_exchange = StatusExchange()
 
@@ -258,7 +277,9 @@ def run_with_configs(global_config: GlobalConfig, user_configs: Sequence[UserCon
 
     if not watch_interval:
         # No watch mode - process each user once and exit
-        return _process_all_users_once(global_config, user_configs, logger, shared_status_exchange)
+        return _process_all_users_once(
+            global_config, user_configs, logger, shared_status_exchange, metrics
+        )
     else:
         # Watch mode - infinite loop processing all users, then wait
         skip_bar = not os.environ.get("FORCE_TQDM") and (
@@ -270,7 +291,7 @@ def run_with_configs(global_config: GlobalConfig, user_configs: Sequence[UserCon
         while True:
             # Process all user configs in this iteration
             result = _process_all_users_once(
-                global_config, user_configs, logger, shared_status_exchange
+                global_config, user_configs, logger, shared_status_exchange, metrics
             )
 
             # If any critical operation (auth-only, list commands) succeeded, exit
@@ -314,6 +335,7 @@ def _process_all_users_once(
     user_configs: Sequence[UserConfig],
     logger: logging.Logger,
     shared_status_exchange: StatusExchange,
+    metrics: MetricsCollector,
 ) -> int:
     """Process all user configs once (used by both single run and watch mode)"""
 
@@ -414,6 +436,7 @@ def _process_all_users_once(
                     lp_filename_generator,
                     filename_builder,
                     user_config.align_raw,
+                    metrics,
                 )
                 if user_config.directory is not None
                 else (lambda _s, _c, _p: False)
@@ -445,6 +468,7 @@ def _process_all_users_once(
                 downloader,
                 notificator,
                 lp_filename_generator,
+                metrics,
             )
 
             # If any user config fails and we're not in watch mode, return the error code
@@ -577,6 +601,7 @@ def download_builder(
     lp_filename_generator: Callable[[str], str],
     filename_builder: Callable[[PhotoAsset], str],
     raw_policy: RawTreatmentPolicy,
+    metrics: MetricsCollector,
     icloud: PyiCloudService,
     counter: Counter,
     photo: PhotoAsset,
@@ -700,6 +725,7 @@ def download_builder(
                     version,
                     download_size,
                     filename_builder,
+                    metrics,
                 )
                 success = download_result
 
@@ -798,6 +824,7 @@ def download_builder(
                         version,
                         lp_size,
                         filename_builder,
+                        metrics,
                     )
                     success = download_result and success
                     if download_result:
@@ -884,6 +911,7 @@ def core_single_run(
     downloader: Callable[[PyiCloudService, Counter, PhotoAsset], bool],
     notificator: Callable[[], None],
     lp_filename_generator: Callable[[str], str],
+    metrics: MetricsCollector,
 ) -> int:
     """Download all iCloud photos to a local directory for a single execution (no watch loop)"""
 
@@ -913,6 +941,7 @@ def core_single_run(
                 partial(append_response, captured_responses),
                 user_config.cookie_directory,
                 os.environ.get("CLIENT_ID"),
+                metrics,
             )
 
             # dump captured responses for debugging
@@ -1069,6 +1098,9 @@ def core_single_run(
 
                         download_photo = partial(downloader, icloud)
 
+                        # Track sync timing
+                        sync_start_time = time.perf_counter()
+
                         for item in photos_bar:
                             try:
                                 if should_break(consecutive_files_found):
@@ -1081,9 +1113,25 @@ def core_single_run(
                                 should_delete = False
 
                                 passer_result = passer(item)
+                                # Determine metric name based on asset type
+                                asset_metric = (
+                                    "videos_processed_total"
+                                    if item.item_type == AssetItemType.MOVIE
+                                    else "photos_processed_total"
+                                )
+                                if not passer_result:
+                                    # Photo/video was skipped by filter
+                                    metrics.inc(asset_metric, labels={"action": "skipped"})
+
                                 download_result = passer_result and download_photo(
                                     consecutive_files_found, item
                                 )
+                                if download_result:
+                                    metrics.inc(asset_metric, labels={"action": "downloaded"})
+                                elif passer_result:
+                                    # Passed filter but not downloaded (already exists or failed)
+                                    metrics.inc(asset_metric, labels={"action": "skipped"})
+
                                 if download_result and user_config.delete_after_download:
                                     should_delete = True
 
@@ -1138,6 +1186,7 @@ def core_single_run(
                                             item,
                                             filename_builder_for_delete,
                                         )
+                                    metrics.inc(asset_metric, labels={"action": "deleted"})
 
                                     # retrier(delete_local, error_handler)
                                     photo_album.increment_offset(-1)
@@ -1145,11 +1194,20 @@ def core_single_run(
                                 photos_counter += 1
                                 status_exchange.get_progress().photos_counter = photos_counter
 
+                                # Update progress gauge
+                                if photos_count and photos_count > 0:
+                                    progress_pct = (photos_counter / photos_count) * 100
+                                    metrics.set("current_progress", progress_pct)
+
                                 if status_exchange.get_progress().cancel:
                                     break
 
                             except StopIteration:
                                 break
+
+                        # Record sync duration
+                        sync_duration = time.perf_counter() - sync_start_time
+                        metrics.observe("sync_duration_seconds", sync_duration)
 
                         if global_config.only_print_filenames:
                             return 0
@@ -1161,6 +1219,7 @@ def core_single_run(
                             status_exchange.get_progress().photos_last_message = (
                                 "Iteration was cancelled"
                             )
+                            metrics.inc("sync_runs_total", labels={"status": "cancelled"})
                         else:
                             if user_config.skip_photos or user_config.skip_videos:
                                 photo_video_phrase = (
@@ -1171,7 +1230,9 @@ def core_single_run(
                             message = f"All {photo_video_phrase} have been downloaded"
                             logger.info(message)
                             status_exchange.get_progress().photos_last_message = message
+                            metrics.inc("sync_runs_total", labels={"status": "success"})
                         status_exchange.get_progress().reset()
+                        metrics.set("current_progress", 0)
 
                     if user_config.auto_delete:
                         autodelete_photos(
@@ -1189,6 +1250,8 @@ def core_single_run(
         except PyiCloudFailedLoginException as error:
             logger.info(error)
             dump_responses(logger.debug, captured_responses)
+            metrics.inc("sync_runs_total", labels={"status": "failure"})
+            metrics.inc("api_errors_total", labels={"error_type": "login_failed"})
             if PasswordProvider.WEBUI in global_config.password_providers:
                 update_auth_error_in_webui(status_exchange, str(error))
                 continue
@@ -1197,6 +1260,8 @@ def core_single_run(
         except PyiCloudFailedMFAException as error:
             logger.info(str(error))
             dump_responses(logger.debug, captured_responses)
+            metrics.inc("sync_runs_total", labels={"status": "failure"})
+            metrics.inc("api_errors_total", labels={"error_type": "mfa_failed"})
             if global_config.mfa_provider == MFAProvider.WEBUI:
                 update_auth_error_in_webui(status_exchange, str(error))
                 continue
@@ -1210,6 +1275,8 @@ def core_single_run(
         ) as error:
             logger.info(error)
             dump_responses(logger.debug, captured_responses)
+            metrics.inc("sync_runs_total", labels={"status": "failure"})
+            metrics.inc("api_errors_total", labels={"error_type": "api_error"})
             # webui will display error and wait for password again
             if (
                 PasswordProvider.WEBUI in global_config.password_providers
@@ -1232,10 +1299,13 @@ def core_single_run(
         ) as error:
             logger.debug(error)
             logger.debug("Retrying...")
+            metrics.inc("api_errors_total", labels={"error_type": "connection_error"})
             # these errors we can safely retry
             continue
         except Exception:
             dump_responses(logger.debug, captured_responses)
+            metrics.inc("sync_runs_total", labels={"status": "failure"})
+            metrics.inc("api_errors_total", labels={"error_type": "unknown"})
             raise
 
         # In single run mode, we don't handle watch intervals - that's done at higher level

--- a/src/icloudpd/cli.py
+++ b/src/icloudpd/cli.py
@@ -13,7 +13,7 @@ import foundation
 from foundation.core import chain_from_iterable, compose, map_, partial_1_1, skip
 from foundation.string_utils import lower
 from icloudpd.base import ensure_tzinfo, run_with_configs
-from icloudpd.config import GlobalConfig, UserConfig
+from icloudpd.config import GlobalConfig, MetricsBackend, MetricsConfig, UserConfig
 from icloudpd.log_level import LogLevel
 from icloudpd.mfa_provider import MFAProvider
 from icloudpd.password_provider import PasswordProvider
@@ -358,6 +358,47 @@ def add_global_options(parser: argparse.ArgumentParser) -> argparse.ArgumentPars
         default="console",
         type=lower,
     )
+    # Metrics configuration
+    cloned.add_argument(
+        "--metrics-backend",
+        help="Metrics backend to use for observability. Default: %(default)s",
+        choices=["none", "prometheus", "statsd", "both"],
+        default="none",
+        type=lower,
+    )
+    cloned.add_argument(
+        "--prometheus-port",
+        help="Port for Prometheus metrics HTTP server. Default: %(default)i",
+        type=int,
+        default=9090,
+    )
+    cloned.add_argument(
+        "--prometheus-host",
+        help="Host to bind Prometheus metrics HTTP server. Default: %(default)s",
+        default="0.0.0.0",
+    )
+    cloned.add_argument(
+        "--statsd-host",
+        help="StatsD server host. Default: %(default)s",
+        default="localhost",
+    )
+    cloned.add_argument(
+        "--statsd-port",
+        help="StatsD server port. Default: %(default)i",
+        type=int,
+        default=8125,
+    )
+    cloned.add_argument(
+        "--statsd-prefix",
+        help="Prefix for StatsD metric names. Default: %(default)s",
+        default="icloudpd",
+    )
+    cloned.add_argument(
+        "--metrics-instance",
+        help="Instance label to add to all metrics for identifying this icloudpd instance. "
+        "Useful when running multiple instances (e.g., for different users).",
+        default=None,
+    )
     return cloned
 
 
@@ -528,6 +569,15 @@ def parse(args: Sequence[str]) -> Tuple[GlobalConfig, Sequence[UserConfig]]:
                 )
             ),
             mfa_provider=MFAProvider(global_ns.mfa_provider),
+            metrics=MetricsConfig(
+                backend=MetricsBackend(global_ns.metrics_backend),
+                prometheus_host=global_ns.prometheus_host,
+                prometheus_port=global_ns.prometheus_port,
+                statsd_host=global_ns.statsd_host,
+                statsd_port=global_ns.statsd_port,
+                statsd_prefix=global_ns.statsd_prefix,
+                instance=global_ns.metrics_instance,
+            ),
         ),
         user_nses,
     )

--- a/src/icloudpd/config.py
+++ b/src/icloudpd/config.py
@@ -1,6 +1,7 @@
 import datetime
 import pathlib
 from dataclasses import dataclass
+from enum import Enum
 from typing import Sequence
 
 from icloudpd.log_level import LogLevel
@@ -10,6 +11,28 @@ from pyicloud_ipd.file_match import FileMatchPolicy
 from pyicloud_ipd.live_photo_mov_filename_policy import LivePhotoMovFilenamePolicy
 from pyicloud_ipd.raw_policy import RawTreatmentPolicy
 from pyicloud_ipd.version_size import AssetVersionSize, LivePhotoVersionSize
+
+
+class MetricsBackend(Enum):
+    """Available metrics backends"""
+
+    NONE = "none"
+    PROMETHEUS = "prometheus"
+    STATSD = "statsd"
+    BOTH = "both"
+
+
+@dataclass(kw_only=True)
+class MetricsConfig:
+    """Configuration for metrics collection"""
+
+    backend: MetricsBackend
+    prometheus_host: str
+    prometheus_port: int
+    statsd_host: str
+    statsd_port: int
+    statsd_prefix: str
+    instance: str | None
 
 
 @dataclass(kw_only=True)
@@ -71,3 +94,4 @@ class GlobalConfig:
     watch_with_interval: int | None
     password_providers: Sequence[PasswordProvider]
     mfa_provider: MFAProvider
+    metrics: MetricsConfig

--- a/src/icloudpd/download.py
+++ b/src/icloudpd/download.py
@@ -13,6 +13,7 @@ from tzlocal import get_localzone
 
 # Import the constants object so that we can mock WAIT_SECONDS in tests
 from icloudpd import constants
+from icloudpd.metrics import MetricsCollector, NoOpCollector
 from pyicloud_ipd.asset_version import AssetVersion, calculate_version_filename
 from pyicloud_ipd.base import PyiCloudService
 from pyicloud_ipd.exceptions import PyiCloudAPIResponseException
@@ -112,11 +113,19 @@ def download_media(
     version: AssetVersion,
     size: VersionSize,
     filename_builder: Callable[[PhotoAsset], str],
+    metrics: MetricsCollector | None = None,
 ) -> bool:
     """Download the photo to path, with retries and error handling"""
 
+    # Use NoOpCollector if no metrics provided for backwards compatibility
+    if metrics is None:
+        metrics = NoOpCollector()
+
+    size_label = size.value if hasattr(size, "value") else str(size)
+
     mkdirs_local = mkdirs_for_path_dry_run if dry_run else mkdirs_for_path
     if not mkdirs_local(logger, download_path):
+        metrics.inc("downloads_total", labels={"status": "failure", "size": size_label})
         return False
 
     checksum = base64.b64decode(version.checksum)
@@ -129,6 +138,7 @@ def download_media(
     )
 
     retries = 0
+    download_start_time = time.perf_counter()
     while True:
         try:
             append_mode = os.path.exists(temp_download_path)
@@ -138,9 +148,24 @@ def download_media(
 
             photo_response = photo.download(icloud.photos.session, version.url, current_size)
             if photo_response.ok:
-                return download_local(
+                result = download_local(
                     photo_response, temp_download_path, append_mode, download_path, photo.created
                 )
+                if result:
+                    # Record successful download metrics
+                    download_duration = time.perf_counter() - download_start_time
+                    metrics.observe(
+                        "download_duration_seconds", download_duration, labels={"size": size_label}
+                    )
+                    metrics.inc("downloads_total", labels={"status": "success", "size": size_label})
+                    # Track bytes downloaded (version.size is the file size)
+                    if hasattr(version, "size") and version.size:
+                        metrics.inc(
+                            "download_bytes_total",
+                            value=float(version.size),
+                            labels={"size": size_label},
+                        )
+                return result
             else:
                 # Use the standard original filename generator for error logging
                 from icloudpd.base import lp_filename_original as simple_lp_filename_generator
@@ -155,11 +180,13 @@ def download_media(
                     version_filename,
                     size.value,
                 )
+                metrics.inc("downloads_total", labels={"status": "failure", "size": size_label})
                 break
 
         except PyiCloudAPIResponseException as ex:
             if "Invalid global session" in str(ex):
                 logger.error("Session error, re-authenticating...")
+                metrics.inc("download_retries_total", labels={"reason": "session"})
                 if retries > 0:
                     # If the first re-authentication attempt failed,
                     # start waiting a few seconds before retrying in case
@@ -172,6 +199,7 @@ def download_media(
                 if retries == constants.MAX_RETRIES:
                     break
                 # you end up here when p.e. throttling by Apple happens
+                metrics.inc("download_retries_total", labels={"reason": "throttle"})
                 wait_time = (retries + 1) * constants.WAIT_SECONDS
                 # Get the proper filename for error messages
                 error_filename = filename_builder(photo)
@@ -188,6 +216,8 @@ def download_media(
                 + "Skipping this file...",
                 download_path,
             )
+            metrics.inc("download_retries_total", labels={"reason": "io"})
+            metrics.inc("downloads_total", labels={"status": "failure", "size": size_label})
             break
         retries = retries + 1
         if retries >= constants.MAX_RETRIES:
@@ -199,5 +229,6 @@ def download_media(
             "Could not download %s. Please try again later.",
             error_filename,
         )
+        metrics.inc("downloads_total", labels={"status": "failure", "size": size_label})
 
     return False

--- a/src/icloudpd/metrics/__init__.py
+++ b/src/icloudpd/metrics/__init__.py
@@ -1,0 +1,59 @@
+"""Metrics collection package for iCloud Photos Downloader.
+
+Provides Prometheus and StatsD metrics support with a unified interface.
+"""
+
+from icloudpd.metrics.collector import CompositeCollector, MetricsCollector, NoOpCollector
+
+__all__ = [
+    "MetricsCollector",
+    "NoOpCollector",
+    "CompositeCollector",
+    "create_metrics_collector",
+]
+
+
+def create_metrics_collector(
+    backend: str,
+    prometheus_host: str = "0.0.0.0",
+    prometheus_port: int = 9090,
+    statsd_host: str = "localhost",
+    statsd_port: int = 8125,
+    statsd_prefix: str = "icloudpd",
+    instance: str | None = None,
+) -> MetricsCollector:
+    """Factory function to create the appropriate metrics collector.
+
+    Args:
+        backend: One of 'none', 'prometheus', 'statsd', or 'both'
+        prometheus_host: Host to bind Prometheus HTTP server (default: 0.0.0.0)
+        prometheus_port: Port for Prometheus HTTP server (default: 9090)
+        statsd_host: StatsD server host (default: localhost)
+        statsd_port: StatsD server port (default: 8125)
+        statsd_prefix: Prefix for StatsD metric names (default: icloudpd)
+        instance: Optional instance label to add to all metrics
+
+    Returns:
+        MetricsCollector instance for the specified backend
+    """
+    if backend == "none":
+        return NoOpCollector()
+
+    collectors: list[MetricsCollector] = []
+
+    if backend in ("prometheus", "both"):
+        from icloudpd.metrics.prometheus_collector import PrometheusCollector
+
+        collectors.append(PrometheusCollector(prometheus_host, prometheus_port, instance))
+
+    if backend in ("statsd", "both"):
+        from icloudpd.metrics.statsd_collector import StatsDCollector
+
+        collectors.append(StatsDCollector(statsd_host, statsd_port, statsd_prefix, instance))
+
+    if len(collectors) == 0:
+        return NoOpCollector()
+    elif len(collectors) == 1:
+        return collectors[0]
+    else:
+        return CompositeCollector(collectors)

--- a/src/icloudpd/metrics/collector.py
+++ b/src/icloudpd/metrics/collector.py
@@ -1,0 +1,162 @@
+"""Metrics collector interface and NoOp implementation"""
+
+from abc import ABC, abstractmethod
+from contextlib import contextmanager
+from typing import Dict, Generator
+
+
+class MetricsCollector(ABC):
+    """Abstract base class for metrics collection.
+
+    Provides a unified interface for different metrics backends (Prometheus, StatsD, etc.).
+    Uses the strategy pattern to allow swapping implementations without changing calling code.
+    """
+
+    _instance: str | None = None
+
+    def _merge_labels(self, labels: Dict[str, str] | None) -> Dict[str, str]:
+        """Merge instance label with provided labels.
+
+        Args:
+            labels: Optional labels from the caller
+
+        Returns:
+            Labels with instance added (empty string if not configured)
+        """
+        merged = {"instance": self._instance or ""}
+        if labels:
+            merged.update(labels)
+        return merged
+
+    @abstractmethod
+    def inc(self, name: str, value: float = 1.0, labels: Dict[str, str] | None = None) -> None:
+        """Increment a counter metric.
+
+        Args:
+            name: The metric name (e.g., 'downloads_total')
+            value: Amount to increment by (default: 1.0)
+            labels: Optional labels/tags for the metric
+        """
+        pass
+
+    @abstractmethod
+    def set(self, name: str, value: float, labels: Dict[str, str] | None = None) -> None:
+        """Set a gauge metric to a specific value.
+
+        Args:
+            name: The metric name (e.g., 'current_progress')
+            value: The value to set
+            labels: Optional labels/tags for the metric
+        """
+        pass
+
+    @abstractmethod
+    def observe(self, name: str, value: float, labels: Dict[str, str] | None = None) -> None:
+        """Record an observation for a histogram/summary metric.
+
+        Args:
+            name: The metric name (e.g., 'download_duration_seconds')
+            value: The observed value
+            labels: Optional labels/tags for the metric
+        """
+        pass
+
+    @contextmanager
+    def time(self, name: str, labels: Dict[str, str] | None = None) -> Generator[None, None, None]:
+        """Context manager for timing operations.
+
+        Args:
+            name: The metric name for the duration histogram
+            labels: Optional labels/tags for the metric
+
+        Example:
+            with metrics.time('download_duration_seconds', {'size': 'original'}):
+                download_file()
+        """
+        import time
+
+        start = time.perf_counter()
+        try:
+            yield
+        finally:
+            duration = time.perf_counter() - start
+            self.observe(name, duration, labels)
+
+    @abstractmethod
+    def start_server(self) -> None:
+        """Start the metrics server (if applicable for the backend)."""
+        pass
+
+    @abstractmethod
+    def stop_server(self) -> None:
+        """Stop the metrics server (if applicable for the backend)."""
+        pass
+
+
+class NoOpCollector(MetricsCollector):
+    """No-operation metrics collector.
+
+    Used when metrics are disabled. All methods are no-ops with minimal overhead.
+    This is the default collector when --metrics-backend is 'none'.
+    """
+
+    def inc(self, name: str, value: float = 1.0, labels: Dict[str, str] | None = None) -> None:
+        """No-op increment."""
+        pass
+
+    def set(self, name: str, value: float, labels: Dict[str, str] | None = None) -> None:
+        """No-op set."""
+        pass
+
+    def observe(self, name: str, value: float, labels: Dict[str, str] | None = None) -> None:
+        """No-op observe."""
+        pass
+
+    @contextmanager
+    def time(self, name: str, labels: Dict[str, str] | None = None) -> Generator[None, None, None]:
+        """No-op timer - yields without measuring."""
+        yield
+
+    def start_server(self) -> None:
+        """No-op start server."""
+        pass
+
+    def stop_server(self) -> None:
+        """No-op stop server."""
+        pass
+
+
+class CompositeCollector(MetricsCollector):
+    """Composite collector that delegates to multiple backends.
+
+    Used when --metrics-backend is 'both' to send metrics to both
+    Prometheus and StatsD simultaneously.
+    """
+
+    def __init__(self, collectors: list[MetricsCollector]) -> None:
+        self._collectors = collectors
+
+    def inc(self, name: str, value: float = 1.0, labels: Dict[str, str] | None = None) -> None:
+        """Increment on all collectors."""
+        for collector in self._collectors:
+            collector.inc(name, value, labels)
+
+    def set(self, name: str, value: float, labels: Dict[str, str] | None = None) -> None:
+        """Set on all collectors."""
+        for collector in self._collectors:
+            collector.set(name, value, labels)
+
+    def observe(self, name: str, value: float, labels: Dict[str, str] | None = None) -> None:
+        """Observe on all collectors."""
+        for collector in self._collectors:
+            collector.observe(name, value, labels)
+
+    def start_server(self) -> None:
+        """Start server on all collectors."""
+        for collector in self._collectors:
+            collector.start_server()
+
+    def stop_server(self) -> None:
+        """Stop server on all collectors."""
+        for collector in self._collectors:
+            collector.stop_server()

--- a/src/icloudpd/metrics/prometheus_collector.py
+++ b/src/icloudpd/metrics/prometheus_collector.py
@@ -1,0 +1,248 @@
+import logging
+from threading import Thread
+from typing import Any, Dict
+
+from icloudpd.metrics.collector import MetricsCollector
+
+LOGGER = logging.getLogger(__name__)
+
+# Global storage for Prometheus metrics to avoid duplicate registration
+_PROMETHEUS_METRICS: Dict[str, Any] = {}
+
+
+class PrometheusCollector(MetricsCollector):
+    """Prometheus metrics collector with HTTP server.
+
+    Exposes metrics on a dedicated HTTP endpoint for Prometheus scraping.
+    Uses prometheus_client library for metric types and HTTP server.
+    """
+
+    def __init__(
+        self, host: str = "0.0.0.0", port: int = 9090, instance: str | None = None
+    ) -> None:
+        """Initialize Prometheus collector.
+
+        Args:
+            host: Host to bind the HTTP server (default: 0.0.0.0)
+            port: Port for the HTTP server (default: 9090)
+            instance: Optional instance label to add to all metrics
+        """
+        self._host = host
+        self._port = port
+        self._instance = instance
+        self._server: Thread | None = None
+        self._server_started = False
+
+        global _PROMETHEUS_METRICS
+
+        # Import prometheus_client here to make it an optional dependency
+        try:
+            from prometheus_client import REGISTRY, Counter, Gauge, Histogram
+
+            self._prometheus_available = True
+        except ImportError:
+            LOGGER.warning(
+                "prometheus_client not installed. Prometheus metrics will be disabled. "
+                "Install with: pip install prometheus_client"
+            )
+            self._prometheus_available = False
+            return
+
+        # Use global metrics dictionary to ensure metrics are only registered once
+        # This handles both tests (multiple instances) and application restarts
+        if not _PROMETHEUS_METRICS:
+            # First time initialization - create all metrics
+            _PROMETHEUS_METRICS["downloads_total"] = Counter(
+                "icloudpd_downloads_total",
+                "Total number of download operations",
+                ["instance", "status", "size"],
+                registry=REGISTRY,
+            )
+            _PROMETHEUS_METRICS["download_bytes_total"] = Counter(
+                "icloudpd_download_bytes_total",
+                "Total bytes downloaded",
+                ["instance", "size"],
+                registry=REGISTRY,
+            )
+            _PROMETHEUS_METRICS["download_duration_seconds"] = Histogram(
+                "icloudpd_download_duration_seconds",
+                "Time spent downloading files",
+                ["instance", "size"],
+                buckets=(0.1, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0, 60.0, 120.0, 300.0, float("inf")),
+                registry=REGISTRY,
+            )
+            _PROMETHEUS_METRICS["download_retries_total"] = Counter(
+                "icloudpd_download_retries_total",
+                "Total number of download retries",
+                ["instance", "reason"],
+                registry=REGISTRY,
+            )
+            _PROMETHEUS_METRICS["api_requests_total"] = Counter(
+                "icloudpd_api_requests_total",
+                "Total number of API requests",
+                ["instance", "method", "status_code"],
+                registry=REGISTRY,
+            )
+            _PROMETHEUS_METRICS["api_request_duration_seconds"] = Histogram(
+                "icloudpd_api_request_duration_seconds",
+                "Time spent on API requests",
+                ["instance", "method"],
+                buckets=(0.01, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, float("inf")),
+                registry=REGISTRY,
+            )
+            _PROMETHEUS_METRICS["api_errors_total"] = Counter(
+                "icloudpd_api_errors_total",
+                "Total number of API errors",
+                ["instance", "error_type"],
+                registry=REGISTRY,
+            )
+            _PROMETHEUS_METRICS["auth_attempts_total"] = Counter(
+                "icloudpd_auth_attempts_total",
+                "Total number of authentication attempts",
+                ["instance", "result", "method"],
+                registry=REGISTRY,
+            )
+            _PROMETHEUS_METRICS["auth_mfa_requests_total"] = Counter(
+                "icloudpd_auth_mfa_requests_total",
+                "Total number of MFA requests",
+                ["instance", "type"],
+                registry=REGISTRY,
+            )
+            _PROMETHEUS_METRICS["photos_processed_total"] = Counter(
+                "icloudpd_photos_processed_total",
+                "Total number of photos processed",
+                ["instance", "action"],
+                registry=REGISTRY,
+            )
+            _PROMETHEUS_METRICS["videos_processed_total"] = Counter(
+                "icloudpd_videos_processed_total",
+                "Total number of videos processed",
+                ["instance", "action"],
+                registry=REGISTRY,
+            )
+            _PROMETHEUS_METRICS["sync_runs_total"] = Counter(
+                "icloudpd_sync_runs_total",
+                "Total number of sync runs",
+                ["instance", "status"],
+                registry=REGISTRY,
+            )
+            _PROMETHEUS_METRICS["sync_duration_seconds"] = Histogram(
+                "icloudpd_sync_duration_seconds",
+                "Time spent on sync operations",
+                ["instance"],
+                buckets=(1.0, 5.0, 10.0, 30.0, 60.0, 300.0, 600.0, 1800.0, 3600.0, float("inf")),
+                registry=REGISTRY,
+            )
+            _PROMETHEUS_METRICS["current_progress"] = Gauge(
+                "icloudpd_current_progress",
+                "Current progress percentage",
+                ["instance"],
+                registry=REGISTRY,
+            )
+            _PROMETHEUS_METRICS["up"] = Gauge(
+                "icloudpd_up",
+                "Whether icloudpd is running",
+                ["instance"],
+                registry=REGISTRY,
+            )
+
+        # Reference the global metrics
+        self._downloads_total = _PROMETHEUS_METRICS["downloads_total"]
+        self._download_bytes_total = _PROMETHEUS_METRICS["download_bytes_total"]
+        self._download_duration_seconds = _PROMETHEUS_METRICS["download_duration_seconds"]
+        self._download_retries_total = _PROMETHEUS_METRICS["download_retries_total"]
+        self._api_requests_total = _PROMETHEUS_METRICS["api_requests_total"]
+        self._api_request_duration_seconds = _PROMETHEUS_METRICS["api_request_duration_seconds"]
+        self._api_errors_total = _PROMETHEUS_METRICS["api_errors_total"]
+        self._auth_attempts_total = _PROMETHEUS_METRICS["auth_attempts_total"]
+        self._auth_mfa_requests_total = _PROMETHEUS_METRICS["auth_mfa_requests_total"]
+        self._photos_processed_total = _PROMETHEUS_METRICS["photos_processed_total"]
+        self._videos_processed_total = _PROMETHEUS_METRICS["videos_processed_total"]
+        self._sync_runs_total = _PROMETHEUS_METRICS["sync_runs_total"]
+        self._sync_duration_seconds = _PROMETHEUS_METRICS["sync_duration_seconds"]
+        self._current_progress = _PROMETHEUS_METRICS["current_progress"]
+        self._up = _PROMETHEUS_METRICS["up"]
+
+        # Map metric names to their prometheus objects and types
+        self._counters: Dict[str, Counter] = {
+            "downloads_total": self._downloads_total,
+            "download_bytes_total": self._download_bytes_total,
+            "download_retries_total": self._download_retries_total,
+            "api_requests_total": self._api_requests_total,
+            "api_errors_total": self._api_errors_total,
+            "auth_attempts_total": self._auth_attempts_total,
+            "auth_mfa_requests_total": self._auth_mfa_requests_total,
+            "photos_processed_total": self._photos_processed_total,
+            "videos_processed_total": self._videos_processed_total,
+            "sync_runs_total": self._sync_runs_total,
+        }
+        self._histograms: Dict[str, Histogram] = {
+            "download_duration_seconds": self._download_duration_seconds,
+            "api_request_duration_seconds": self._api_request_duration_seconds,
+            "sync_duration_seconds": self._sync_duration_seconds,
+        }
+        self._gauges: Dict[str, Gauge] = {
+            "current_progress": self._current_progress,
+            "up": self._up,
+        }
+
+    def inc(self, name: str, value: float = 1.0, labels: Dict[str, str] | None = None) -> None:
+        """Increment a counter metric."""
+        if not self._prometheus_available:
+            return
+
+        merged = self._merge_labels(labels)
+        if name in self._counters:
+            counter = self._counters[name]
+            counter.labels(**merged).inc(value)
+        else:
+            LOGGER.debug(f"Unknown counter metric: {name}")
+
+    def set(self, name: str, value: float, labels: Dict[str, str] | None = None) -> None:
+        """Set a gauge metric."""
+        if not self._prometheus_available:
+            return
+
+        merged = self._merge_labels(labels)
+        if name in self._gauges:
+            gauge = self._gauges[name]
+            gauge.labels(**merged).set(value)
+        else:
+            LOGGER.debug(f"Unknown gauge metric: {name}")
+
+    def observe(self, name: str, value: float, labels: Dict[str, str] | None = None) -> None:
+        """Record an observation for a histogram."""
+        if not self._prometheus_available:
+            return
+
+        merged = self._merge_labels(labels)
+        if name in self._histograms:
+            histogram = self._histograms[name]
+            histogram.labels(**merged).observe(value)
+        else:
+            LOGGER.debug(f"Unknown histogram metric: {name}")
+
+    def start_server(self) -> None:
+        """Start the Prometheus HTTP server in a daemon thread."""
+        if not self._prometheus_available:
+            return
+
+        if self._server_started:
+            return
+
+        from prometheus_client import start_http_server
+
+        try:
+            start_http_server(self._port, addr=self._host)
+            self._server_started = True
+            LOGGER.info(f"Prometheus metrics server started on {self._host}:{self._port}")
+        except OSError as e:
+            LOGGER.error(f"Failed to start Prometheus server on {self._host}:{self._port}: {e}")
+
+    def stop_server(self) -> None:
+        """Stop the Prometheus HTTP server.
+
+        Note: prometheus_client's start_http_server doesn't provide a clean way to stop.
+        The server runs in a daemon thread, so it will stop when the main process exits.
+        """
+        self._server_started = False

--- a/src/icloudpd/metrics/statsd_collector.py
+++ b/src/icloudpd/metrics/statsd_collector.py
@@ -1,0 +1,112 @@
+"""StatsD metrics collector implementation"""
+
+import logging
+from typing import Dict
+
+from icloudpd.metrics.collector import MetricsCollector
+
+LOGGER = logging.getLogger(__name__)
+
+
+class StatsDCollector(MetricsCollector):
+    """StatsD metrics collector using UDP protocol.
+
+    Sends metrics to a StatsD server using the standard StatsD protocol.
+    Uses the statsd library for UDP client functionality.
+    """
+
+    def __init__(
+        self,
+        host: str = "localhost",
+        port: int = 8125,
+        prefix: str = "icloudpd",
+        instance: str | None = None,
+    ) -> None:
+        """Initialize StatsD collector.
+
+        Args:
+            host: StatsD server host (default: localhost)
+            port: StatsD server port (default: 8125)
+            prefix: Prefix for all metric names (default: icloudpd)
+            instance: Optional instance label to add to all metrics
+        """
+        self._host = host
+        self._port = port
+        self._prefix = prefix
+        self._instance = instance
+        self._client = None
+
+        try:
+            import statsd
+
+            self._client = statsd.StatsClient(host, port, prefix=prefix)
+            self._statsd_available = True
+            LOGGER.info(f"StatsD client configured for {host}:{port} with prefix '{prefix}'")
+        except ImportError:
+            LOGGER.warning(
+                "statsd library not installed. StatsD metrics will be disabled. "
+                "Install with: pip install statsd"
+            )
+            self._statsd_available = False
+
+    def _build_metric_name(self, name: str, labels: Dict[str, str] | None) -> str:
+        """Build a metric name with labels encoded as tags.
+
+        StatsD doesn't natively support labels, so we encode them in the metric name.
+        Format: metric_name.label1_value1.label2_value2
+
+        Args:
+            name: Base metric name
+            labels: Optional labels to encode
+
+        Returns:
+            Metric name with encoded labels
+        """
+        if not labels:
+            return name
+
+        # Sort labels for consistent naming, filter out empty values
+        label_parts = [f"{k}_{v}" for k, v in sorted(labels.items()) if v]
+        if not label_parts:
+            return name
+        return f"{name}.{'.'.join(label_parts)}"
+
+    def inc(self, name: str, value: float = 1.0, labels: Dict[str, str] | None = None) -> None:
+        """Increment a counter metric."""
+        if not self._statsd_available or not self._client:
+            return
+
+        merged = self._merge_labels(labels)
+        metric_name = self._build_metric_name(name, merged)
+        self._client.incr(metric_name, int(value))
+
+    def set(self, name: str, value: float, labels: Dict[str, str] | None = None) -> None:
+        """Set a gauge metric."""
+        if not self._statsd_available or not self._client:
+            return
+
+        merged = self._merge_labels(labels)
+        metric_name = self._build_metric_name(name, merged)
+        self._client.gauge(metric_name, value)
+
+    def observe(self, name: str, value: float, labels: Dict[str, str] | None = None) -> None:
+        """Record an observation using StatsD timing.
+
+        StatsD doesn't have histograms, so we use timing metrics.
+        The value is expected to be in seconds and will be converted to milliseconds.
+        """
+        if not self._statsd_available or not self._client:
+            return
+
+        merged = self._merge_labels(labels)
+        metric_name = self._build_metric_name(name, merged)
+        # StatsD timing is in milliseconds
+        self._client.timing(metric_name, value * 1000)
+
+    def start_server(self) -> None:
+        """No-op for StatsD (client-side push, no server needed)."""
+        pass
+
+    def stop_server(self) -> None:
+        """No-op for StatsD (client-side push, no server needed)."""
+        pass

--- a/src/pyicloud_ipd/base.py
+++ b/src/pyicloud_ipd/base.py
@@ -86,6 +86,7 @@ class PyiCloudService:
         client_id: str | None = None,
         with_family: bool = True,
         http_timeout: float = 30.0,
+        metrics: Any = None,
     ):
         self.apple_id = apple_id
         self.password_provider: Callable[[], str | None] = password_provider
@@ -96,6 +97,7 @@ class PyiCloudService:
         self.http_timeout = http_timeout
         self.response_observer = response_observer
         self.observer_rules: Sequence[Rule] = []
+        self._metrics = metrics
 
         # set it when we get password
         self.password_filter: PyiCloudPasswordFilter | None = None
@@ -146,7 +148,7 @@ class PyiCloudService:
                 self.response_observer(apply_rules("", self.observer_rules, response))
 
         self.session: PyiCloudSession = PyiCloudSession(
-            self, apply_rules_and_observe if self.response_observer else None
+            self, apply_rules_and_observe if self.response_observer else None, self._metrics
         )
         self.session.verify = verify
         self.session.headers.update(

--- a/src/pyicloud_ipd/session.py
+++ b/src/pyicloud_ipd/session.py
@@ -1,6 +1,7 @@
 import inspect
 import json
 import logging
+import time
 import typing
 from typing import Any, Callable, Dict, Mapping, NoReturn, Sequence
 
@@ -8,6 +9,7 @@ from requests import Response, Session
 from typing_extensions import override
 
 from foundation.http import response_to_har_entry
+from icloudpd.metrics import MetricsCollector, NoOpCollector
 from pyicloud_ipd.exceptions import (
     PyiCloud2SARequiredException,
     PyiCloudAPIResponseException,
@@ -47,10 +49,14 @@ class PyiCloudSession(Session):
     """iCloud session."""
 
     def __init__(
-        self, service: Any, response_observer: Callable[[Mapping[str, Any]], None] | None = None
+        self,
+        service: Any,
+        response_observer: Callable[[Mapping[str, Any]], None] | None = None,
+        metrics: MetricsCollector | None = None,
     ):
         self.service = service
         self.response_observer = response_observer
+        self.metrics = metrics if metrics is not None else NoOpCollector()
         super().__init__()
 
     def observe(self, response: Response) -> Response:
@@ -74,8 +80,21 @@ class PyiCloudSession(Session):
 
         if "timeout" not in kwargs and self.service.http_timeout is not None:
             kwargs["timeout"] = self.service.http_timeout
+
+        # Track API request timing
+        request_start_time = time.perf_counter()
         response = throw_on_503(
             self.observe(handle_connection_error(super().request)(method, url, **kwargs))
+        )
+        request_duration = time.perf_counter() - request_start_time
+
+        # Record API metrics
+        self.metrics.observe(
+            "api_request_duration_seconds", request_duration, labels={"method": method}
+        )
+        self.metrics.inc(
+            "api_requests_total",
+            labels={"method": method, "status_code": str(response.status_code)},
         )
 
         content_type = response.headers.get("Content-Type", "").split(";")[0]
@@ -152,6 +171,9 @@ class PyiCloudSession(Session):
         return response
 
     def _raise_error(self, code: str, reason: str) -> NoReturn:
+        # Track API error
+        self.metrics.inc("api_errors_total", labels={"error_type": code})
+
         if self.service.requires_2sa and reason == "Missing X-APPLE-WEBAUTH-TOKEN cookie":
             raise PyiCloud2SARequiredException(self.service.user["accountName"])
         if code in ("ZONE_NOT_FOUND", "AUTHENTICATION_FAILED"):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10,7 +10,7 @@ from unittest import TestCase
 import pytest
 
 from icloudpd.cli import format_help, parse
-from icloudpd.config import GlobalConfig, UserConfig
+from icloudpd.config import GlobalConfig, MetricsBackend, MetricsConfig, UserConfig
 from icloudpd.log_level import LogLevel
 from icloudpd.mfa_provider import MFAProvider
 from icloudpd.password_provider import PasswordProvider
@@ -22,6 +22,17 @@ from tests.helpers import (
     path_from_project_root,
     run_icloudpd_test,
     run_main,
+)
+
+# Default metrics config used in tests
+DEFAULT_METRICS_CONFIG = MetricsConfig(
+    backend=MetricsBackend.NONE,
+    prometheus_host="0.0.0.0",
+    prometheus_port=9090,
+    statsd_host="localhost",
+    statsd_port=8125,
+    statsd_prefix="icloudpd",
+    instance=None,
 )
 
 
@@ -90,6 +101,7 @@ class CliTestCase(TestCase):
                         PasswordProvider.CONSOLE,
                     ],
                     mfa_provider=MFAProvider.CONSOLE,
+                    metrics=DEFAULT_METRICS_CONFIG,
                 ),
                 [],
             ),
@@ -114,6 +126,7 @@ class CliTestCase(TestCase):
                         PasswordProvider.CONSOLE,
                     ],
                     mfa_provider=MFAProvider.WEBUI,
+                    metrics=DEFAULT_METRICS_CONFIG,
                 ),
                 [],
             ),
@@ -143,6 +156,7 @@ class CliTestCase(TestCase):
                     watch_with_interval=None,
                     password_providers=[PasswordProvider.WEBUI, PasswordProvider.CONSOLE],
                     mfa_provider=MFAProvider.CONSOLE,
+                    metrics=DEFAULT_METRICS_CONFIG,
                 ),
                 [],
             ),
@@ -167,6 +181,7 @@ class CliTestCase(TestCase):
                         PasswordProvider.CONSOLE,
                     ],
                     mfa_provider=MFAProvider.CONSOLE,
+                    metrics=DEFAULT_METRICS_CONFIG,
                 ),
                 [],
             ),
@@ -193,6 +208,7 @@ class CliTestCase(TestCase):
                         PasswordProvider.CONSOLE,
                     ],
                     mfa_provider=MFAProvider.CONSOLE,
+                    metrics=DEFAULT_METRICS_CONFIG,
                 ),
                 [
                     UserConfig(
@@ -309,6 +325,7 @@ class CliTestCase(TestCase):
                         PasswordProvider.CONSOLE,
                     ],
                     mfa_provider=MFAProvider.CONSOLE,
+                    metrics=DEFAULT_METRICS_CONFIG,
                 ),
                 [
                     UserConfig(

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,351 @@
+"""Tests for the metrics module"""
+
+import time
+from unittest.mock import MagicMock, patch
+
+from icloudpd.config import MetricsBackend, MetricsConfig
+from icloudpd.metrics import (
+    CompositeCollector,
+    MetricsCollector,
+    NoOpCollector,
+    create_metrics_collector,
+)
+from icloudpd.metrics.prometheus_collector import PrometheusCollector
+from icloudpd.metrics.statsd_collector import StatsDCollector
+
+
+class TestNoOpCollector:
+    """Tests for the NoOpCollector"""
+
+    def test_inc_does_nothing(self):
+        """Test that inc method is a no-op"""
+        collector = NoOpCollector()
+        # Should not raise any exceptions
+        collector.inc("test_counter")
+        collector.inc("test_counter", value=5.0)
+        collector.inc("test_counter", labels={"label1": "value1"})
+        collector.inc("test_counter", value=10.0, labels={"label1": "value1"})
+
+    def test_set_does_nothing(self):
+        """Test that set method is a no-op"""
+        collector = NoOpCollector()
+        # Should not raise any exceptions
+        collector.set("test_gauge", 42.0)
+        collector.set("test_gauge", 100.0, labels={"label1": "value1"})
+
+    def test_observe_does_nothing(self):
+        """Test that observe method is a no-op"""
+        collector = NoOpCollector()
+        # Should not raise any exceptions
+        collector.observe("test_histogram", 1.5)
+        collector.observe("test_histogram", 2.5, labels={"label1": "value1"})
+
+    def test_time_context_manager_yields_immediately(self):
+        """Test that time context manager yields without measuring"""
+        collector = NoOpCollector()
+        start = time.perf_counter()
+        with collector.time("test_duration"):
+            pass
+        elapsed = time.perf_counter() - start
+        # Should complete almost instantly (no actual timing)
+        assert elapsed < 0.01
+
+    def test_start_stop_server_does_nothing(self):
+        """Test that server methods are no-ops"""
+        collector = NoOpCollector()
+        # Should not raise any exceptions
+        collector.start_server()
+        collector.stop_server()
+
+
+class TestCompositeCollector:
+    """Tests for the CompositeCollector"""
+
+    def test_inc_delegates_to_all_collectors(self):
+        """Test that inc is called on all collectors"""
+        collector1 = MagicMock(spec=MetricsCollector)
+        collector2 = MagicMock(spec=MetricsCollector)
+        composite = CompositeCollector([collector1, collector2])
+
+        composite.inc("test_counter", value=5.0, labels={"key": "value"})
+
+        collector1.inc.assert_called_once_with("test_counter", 5.0, {"key": "value"})
+        collector2.inc.assert_called_once_with("test_counter", 5.0, {"key": "value"})
+
+    def test_set_delegates_to_all_collectors(self):
+        """Test that set is called on all collectors"""
+        collector1 = MagicMock(spec=MetricsCollector)
+        collector2 = MagicMock(spec=MetricsCollector)
+        composite = CompositeCollector([collector1, collector2])
+
+        composite.set("test_gauge", 42.0, labels={"key": "value"})
+
+        collector1.set.assert_called_once_with("test_gauge", 42.0, {"key": "value"})
+        collector2.set.assert_called_once_with("test_gauge", 42.0, {"key": "value"})
+
+    def test_observe_delegates_to_all_collectors(self):
+        """Test that observe is called on all collectors"""
+        collector1 = MagicMock(spec=MetricsCollector)
+        collector2 = MagicMock(spec=MetricsCollector)
+        composite = CompositeCollector([collector1, collector2])
+
+        composite.observe("test_histogram", 1.5, labels={"key": "value"})
+
+        collector1.observe.assert_called_once_with("test_histogram", 1.5, {"key": "value"})
+        collector2.observe.assert_called_once_with("test_histogram", 1.5, {"key": "value"})
+
+    def test_start_server_delegates_to_all_collectors(self):
+        """Test that start_server is called on all collectors"""
+        collector1 = MagicMock(spec=MetricsCollector)
+        collector2 = MagicMock(spec=MetricsCollector)
+        composite = CompositeCollector([collector1, collector2])
+
+        composite.start_server()
+
+        collector1.start_server.assert_called_once()
+        collector2.start_server.assert_called_once()
+
+    def test_stop_server_delegates_to_all_collectors(self):
+        """Test that stop_server is called on all collectors"""
+        collector1 = MagicMock(spec=MetricsCollector)
+        collector2 = MagicMock(spec=MetricsCollector)
+        composite = CompositeCollector([collector1, collector2])
+
+        composite.stop_server()
+
+        collector1.stop_server.assert_called_once()
+        collector2.stop_server.assert_called_once()
+
+
+class TestPrometheusCollector:
+    """Tests for the PrometheusCollector"""
+
+    def test_inc_counter(self):
+        """Test incrementing a counter"""
+        collector = PrometheusCollector(host="127.0.0.1", port=19090)
+        # Should not raise
+        collector.inc("downloads_total", labels={"status": "success", "size": "original"})
+        collector.inc("downloads_total", value=5.0, labels={"status": "failure", "size": "medium"})
+
+    def test_set_gauge(self):
+        """Test setting a gauge"""
+        collector = PrometheusCollector(host="127.0.0.1", port=18101)
+        # Should not raise
+        collector.set("current_progress", 50.0)
+        collector.set("up", 1.0)
+
+    def test_observe_histogram(self):
+        """Test observing a histogram"""
+        collector = PrometheusCollector(host="127.0.0.1", port=18102)
+        # Should not raise
+        collector.observe("download_duration_seconds", 1.5, labels={"size": "original"})
+        collector.observe("api_request_duration_seconds", 0.5, labels={"method": "GET"})
+
+    def test_unknown_metric_logs_debug(self):
+        """Test that unknown metrics log debug message"""
+        collector = PrometheusCollector(host="127.0.0.1", port=18103)
+        # Should not raise, just log debug
+        collector.inc("unknown_counter")
+        collector.set("unknown_gauge", 1.0)
+        collector.observe("unknown_histogram", 1.0)
+
+
+class TestStatsDCollector:
+    """Tests for the StatsDCollector"""
+
+    def test_build_metric_name_without_labels(self):
+        """Test metric name building without labels"""
+        collector = StatsDCollector(host="127.0.0.1", port=18125, prefix="test")
+        name = collector._build_metric_name("downloads_total", None)
+        assert name == "downloads_total"
+
+    def test_build_metric_name_with_labels(self):
+        """Test metric name building with labels"""
+        collector = StatsDCollector(host="127.0.0.1", port=18126, prefix="test")
+        name = collector._build_metric_name(
+            "downloads_total", {"status": "success", "size": "original"}
+        )
+        # Labels should be sorted alphabetically
+        assert name == "downloads_total.size_original.status_success"
+
+    def test_inc_sends_to_client(self):
+        """Test that inc calls the statsd client"""
+        collector = StatsDCollector(host="127.0.0.1", port=18127, prefix="test")
+        if collector._client:
+            with patch.object(collector._client, "incr") as mock_incr:
+                collector.inc("downloads_total", value=5.0, labels={"status": "success"})
+                mock_incr.assert_called_once_with("downloads_total.status_success", 5)
+
+    def test_set_sends_to_client(self):
+        """Test that set calls the statsd client"""
+        collector = StatsDCollector(host="127.0.0.1", port=18128, prefix="test")
+        if collector._client:
+            with patch.object(collector._client, "gauge") as mock_gauge:
+                collector.set("current_progress", 75.0)
+                mock_gauge.assert_called_once_with("current_progress", 75.0)
+
+    def test_observe_sends_to_client(self):
+        """Test that observe calls the statsd client timing in milliseconds"""
+        collector = StatsDCollector(host="127.0.0.1", port=18129, prefix="test")
+        if collector._client:
+            with patch.object(collector._client, "timing") as mock_timing:
+                collector.observe("download_duration_seconds", 1.5)
+                # Value should be converted to milliseconds
+                mock_timing.assert_called_once_with("download_duration_seconds", 1500.0)
+
+    def test_instance_label_merged_into_metrics(self):
+        """Test that instance label is merged into metric names"""
+        collector = StatsDCollector(host="127.0.0.1", port=18130, prefix="test", instance="user1")
+        if collector._client:
+            with patch.object(collector._client, "incr") as mock_incr:
+                collector.inc("downloads_total", value=1.0, labels={"status": "success"})
+                # instance should be merged with other labels
+                mock_incr.assert_called_once_with(
+                    "downloads_total.instance_user1.status_success", 1
+                )
+
+    def test_instance_label_only_when_no_other_labels(self):
+        """Test that instance label is added when no other labels provided"""
+        collector = StatsDCollector(host="127.0.0.1", port=18131, prefix="test", instance="user2")
+        if collector._client:
+            with patch.object(collector._client, "gauge") as mock_gauge:
+                collector.set("up", 1.0)
+                mock_gauge.assert_called_once_with("up.instance_user2", 1.0)
+
+
+class TestCreateMetricsCollector:
+    """Tests for the create_metrics_collector factory function"""
+
+    def test_none_backend_returns_noop(self):
+        """Test that 'none' backend returns NoOpCollector"""
+        collector = create_metrics_collector(backend="none")
+        assert isinstance(collector, NoOpCollector)
+
+    def test_prometheus_backend_returns_prometheus(self):
+        """Test that 'prometheus' backend returns PrometheusCollector"""
+        collector = create_metrics_collector(
+            backend="prometheus",
+            prometheus_host="127.0.0.1",
+            prometheus_port=18200,
+        )
+        assert isinstance(collector, PrometheusCollector)
+
+    def test_statsd_backend_returns_statsd(self):
+        """Test that 'statsd' backend returns StatsDCollector"""
+        collector = create_metrics_collector(
+            backend="statsd",
+            statsd_host="127.0.0.1",
+            statsd_port=18201,
+            statsd_prefix="test",
+        )
+        assert isinstance(collector, StatsDCollector)
+
+    def test_both_backend_returns_composite(self):
+        """Test that 'both' backend returns CompositeCollector"""
+        collector = create_metrics_collector(
+            backend="both",
+            prometheus_host="127.0.0.1",
+            prometheus_port=18202,
+            statsd_host="127.0.0.1",
+            statsd_port=18203,
+            statsd_prefix="test",
+        )
+        assert isinstance(collector, CompositeCollector)
+
+    def test_unknown_backend_returns_noop(self):
+        """Test that unknown backend returns NoOpCollector"""
+        collector = create_metrics_collector(backend="unknown")
+        assert isinstance(collector, NoOpCollector)
+
+    def test_instance_passed_to_collectors(self):
+        """Test that instance is passed to collectors"""
+        collector = create_metrics_collector(
+            backend="statsd",
+            statsd_host="127.0.0.1",
+            statsd_port=18204,
+            statsd_prefix="test",
+            instance="user1",
+        )
+        assert isinstance(collector, StatsDCollector)
+        assert collector._instance == "user1"
+
+
+class TestMetricsCollectorTimeContextManager:
+    """Tests for the time context manager on MetricsCollector"""
+
+    def test_time_measures_duration(self):
+        """Test that time context manager measures and observes duration"""
+        # For this test, we'll use a concrete collector and verify observe is called
+
+        class TestCollector(MetricsCollector):
+            def __init__(self):
+                self.observed_values = []
+
+            def inc(self, name, value=1.0, labels=None):
+                pass
+
+            def set(self, name, value, labels=None):
+                pass
+
+            def observe(self, name, value, labels=None):
+                self.observed_values.append((name, value, labels))
+
+            def start_server(self):
+                pass
+
+            def stop_server(self):
+                pass
+
+        collector = TestCollector()
+        with collector.time("test_duration", {"label": "value"}):
+            time.sleep(0.01)  # Sleep for 10ms
+
+        assert len(collector.observed_values) == 1
+        name, value, labels = collector.observed_values[0]
+        assert name == "test_duration"
+        assert value >= 0.01  # At least 10ms
+        assert value < 0.5  # But less than 500ms (reasonable upper bound)
+        assert labels == {"label": "value"}
+
+
+class TestMetricsConfig:
+    """Tests for MetricsConfig dataclass"""
+
+    def test_metrics_config_creation(self):
+        """Test creating a MetricsConfig"""
+        config = MetricsConfig(
+            backend=MetricsBackend.PROMETHEUS,
+            prometheus_host="0.0.0.0",
+            prometheus_port=9090,
+            statsd_host="localhost",
+            statsd_port=8125,
+            statsd_prefix="icloudpd",
+            instance="user1",
+        )
+        assert config.backend == MetricsBackend.PROMETHEUS
+        assert config.prometheus_host == "0.0.0.0"
+        assert config.prometheus_port == 9090
+        assert config.statsd_host == "localhost"
+        assert config.statsd_port == 8125
+        assert config.statsd_prefix == "icloudpd"
+        assert config.instance == "user1"
+
+    def test_metrics_config_with_no_instance(self):
+        """Test creating a MetricsConfig without instance"""
+        config = MetricsConfig(
+            backend=MetricsBackend.NONE,
+            prometheus_host="0.0.0.0",
+            prometheus_port=9090,
+            statsd_host="localhost",
+            statsd_port=8125,
+            statsd_prefix="icloudpd",
+            instance=None,
+        )
+        assert config.instance is None
+
+    def test_metrics_backend_enum_values(self):
+        """Test MetricsBackend enum values"""
+        assert MetricsBackend.NONE.value == "none"
+        assert MetricsBackend.PROMETHEUS.value == "prometheus"
+        assert MetricsBackend.STATSD.value == "statsd"
+        assert MetricsBackend.BOTH.value == "both"


### PR DESCRIPTION
As I run icloudpd to continuously backup for myself and family accounts, I wanted a way to monitor and or alert if the runs began to fail. Auth failure metrics could be a work-around to using smtp if you have a method to alert on prometheus metrics. 

Potentially relates to #1072 and #183

Add observability support with two metrics backends:
- Prometheus: HTTP server exposing /metrics endpoint
- StatsD: UDP push to StatsD-compatible servers

Metrics tracked:
- Download operations (count, bytes, duration, retries)
- Photos and videos processed (separate counters)
- Sync runs (count, duration, status)
- API requests (count, duration, errors)
- Authentication attempts and MFA requests

New CLI options:
- --metrics-backend (none|prometheus|statsd|both)
- --prometheus-host, --prometheus-port
- --statsd-host, --statsd-port, --statsd-prefix
- --metrics-instance (for multi-instance deployments)

Also includes:
- Documentation with configuration examples
- Example Grafana dashboard
- Dockerfile exposes port 9090 for Prometheus


Dashboard Example - 
<img width="2528" height="1238" alt="Screenshot 2026-02-04 at 12 08 22 AM" src="https://github.com/user-attachments/assets/7694e94a-4ba9-40ba-8404-da291ef118c7" />
