### PR TITLE
fix: handle Apple's new trustedPhoneNumbers location in auth response

### DIFF
--- a/src/pyicloud_ipd/sms.py
+++ b/src/pyicloud_ipd/sms.py
@@ -65,12 +65,17 @@ def parse_trusted_phone_numbers_payload(content: str) -> Sequence[TrustedDevice]
     parser = _SMSParser()
     parser.feed(content)
     parser.close()
+    twoSV = parser.sms_data.get("direct", {}).get("twoSV", {})
+    # Apple moved trustedPhoneNumbers into bridgeInitiateData.phoneNumberVerification (2026+)
     numbers: Sequence[Mapping[str, Any]] = (
-        parser.sms_data.get("direct", {})
-        .get("twoSV", {})
-        .get("phoneNumberVerification", {})
-        .get("trustedPhoneNumbers", [])
+        twoSV.get("phoneNumberVerification", {}).get("trustedPhoneNumbers", [])
     )
+    if not numbers:
+        numbers = (
+            twoSV.get("bridgeInitiateData", {})
+            .get("phoneNumberVerification", {})
+            .get("trustedPhoneNumbers", [])
+        )
     return list(item for item in map(_map_to_trusted_device, numbers) if item is not None)
 
 


### PR DESCRIPTION
## Summary

- Apple moved `trustedPhoneNumbers` from `twoSV.phoneNumberVerification` to `twoSV.bridgeInitiateData.phoneNumberVerification` in the HTML response from `https://idmsa.apple.com/appleauth/auth`
- This causes `get_trusted_phone_numbers()` to return an empty list, hiding the SMS 2FA option entirely
- Combined with iOS 26 removing the manual "Get Verification Code" button from Settings, users have no way to authenticate
- The fix checks both the original and new location, falling back to `bridgeInitiateData` when the original path is empty

Fixes #1322

## How I found this

Captured the actual Apple auth response and compared the JSON structure to what the parser expects:

```
# What the parser looks for (old):
twoSV.phoneNumberVerification.trustedPhoneNumbers → []  (empty)

# Where Apple now puts it (new):
twoSV.bridgeInitiateData.phoneNumberVerification.trustedPhoneNumbers → [{id: 1, ...}]
```

## Test plan

- [x] Verified the parser returns 0 devices with the unpatched code against a live Apple auth response
- [x] Verified the parser returns the correct trusted phone number after the fix
- [x] Built a patched Docker image and confirmed the SMS option (`a: (***) ***-**88`) now appears in the 2FA prompt
- [x] Backwards compatible: still checks the original location first

🤖 Generated with [Claude Code](https://claude.com/claude-code)