### PR TITLE
fix: parse trusted phone numbers from bridgeInitiateData

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix: parse SMS trusted phone numbers from Apple's `bridgeInitiateData` payload
+
 ## 1.32.2 (2025-09-01)
 
 - fix: HTTP response content not captured for authentication and non-streaming requests [#1240](https://github.com/icloud-photos-downloader/icloud_photos_downloader/issues/1240)

--- a/src/pyicloud_ipd/sms.py
+++ b/src/pyicloud_ipd/sms.py
@@ -65,9 +65,10 @@ def parse_trusted_phone_numbers_payload(content: str) -> Sequence[TrustedDevice]
     parser = _SMSParser()
     parser.feed(content)
     parser.close()
+    two_sv = parser.sms_data.get("direct", {}).get("twoSV", {})
     numbers: Sequence[Mapping[str, Any]] = (
-        parser.sms_data.get("direct", {})
-        .get("twoSV", {})
+        two_sv.get("phoneNumberVerification", {}).get("trustedPhoneNumbers", [])
+        or two_sv.get("bridgeInitiateData", {})
         .get("phoneNumberVerification", {})
         .get("trustedPhoneNumbers", [])
     )

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -202,6 +202,13 @@ class AuthenticationTestCase(TestCase):
         self.assertEqual(1, len(result), "number of numbers parsed")
         self.assertEqual(expected, result[0], "parsed number")
 
+    def test_parse_trusted_phone_numbers_payload_bridge_initiate_data(self) -> None:
+        html = '<script type="application/json" class="boot_args">{"direct":{"twoSV":{"bridgeInitiateData":{"phoneNumberVerification":{"trustedPhoneNumbers":[{"numberWithDialCode":"+1 (•••) •••-••81","pushMode":"sms","obfuscatedNumber":"(•••) •••-••81","lastTwoDigits":"81","id":1}]}},"authInitialRoute":"auth/verify/phone"}}}</script>'  # noqa: E501
+        expected = _TrustedDevice(id=1, obfuscated_number="(***) ***-**81")
+        result = parse_trusted_phone_numbers_payload(html)
+        self.assertEqual(1, len(result), "number of numbers parsed")
+        self.assertEqual(expected, result[0], "parsed number")
+
     def test_parse_trusted_phone_numbers_payload_missing_node0(self) -> None:
         html = '<script type="application/json" class="boot_args">{"MISSINGdirect":{"twoSV":{"phoneNumberVerification":{"trustedPhoneNumbers":[{"numberWithDialCode":"+1 (•••) •••-••81","pushMode":"sms","obfuscatedNumber":"(•••) •••-••81","lastTwoDigits":"81","id":1}]},"authInitialRoute":"auth/verify/phone"}}}</script>'  # noqa: E501
         result = parse_trusted_phone_numbers_payload(html)


### PR DESCRIPTION
## Summary
- handle trusted phone numbers nested under `direct.twoSV.bridgeInitiateData.phoneNumberVerification`
- keep the previous `direct.twoSV.phoneNumberVerification` path as the first lookup
- add a regression test and changelog entry

## Testing
- `UV_CACHE_DIR=/tmp/uv-cache uv run --group test python -m pytest tests/test_authentication.py -k 'parse_trusted_phone_numbers_payload'`
