### PR TITLE
Update GitHub Actions workflows from macos-13 to macos-14

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -548,7 +548,7 @@ jobs:
   
   build_macos:
     # earliest possible mac for better compatibility
-    runs-on: macos-13
+    runs-on: macos-14
     defaults:
       run:
         shell: bash
@@ -1148,7 +1148,7 @@ jobs:
       matrix: 
         prop: 
           - [
-            "macos-13",  # os
+            "macos-14",  # os
             "amd64",  # platform spec
           ]
           - [
@@ -2056,7 +2056,7 @@ jobs:
       matrix:  
         prop:  
           - [ 
-            "macos-13", 
+            "macos-14", 
             "amd64", 
             ] 
           - [ 
@@ -3347,7 +3347,7 @@ jobs:
       matrix: 
         prop:  
           - [ 
-            "macos-13", 
+            "macos-14", 
             "amd64", 
             ] 
           - [ 
@@ -3476,7 +3476,7 @@ jobs:
       matrix: 
         prop:  
           - [ 
-            "macos-13", 
+            "macos-14", 
             "amd64", 
             ] 
           - [ 

--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -124,7 +124,6 @@ jobs:
       matrix: 
         python-version: [3.13]
         os: 
-          - "macos-13"
           - "macos-14"
           - "windows-2025"
           - "windows-2022"


### PR DESCRIPTION
This PR updates GitHub Actions workflow runner references from `macos-13` to `macos-14` in `.github/workflows/build-package.yml` and `.github/workflows/quality-checks.yml` due to macos-13 no longer being available.

https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/