### PR TITLE
fix: handle connection errors during download with retry and skip

### DIFF
--- a/src/icloudpd/download.py
+++ b/src/icloudpd/download.py
@@ -20,6 +20,30 @@ from pyicloud_ipd.services.photos import PhotoAsset
 from pyicloud_ipd.version_size import VersionSize
 
 
+def log_failed_download(download_path: str, error_message: str) -> None:
+    """Append failed download to a log file in the download directory's root."""
+    # Find the iCloud backup root (go up until we find a non-date directory)
+    path_parts = download_path.split(os.sep)
+    # Look for the pattern: .../iCloud_Backup/YYYY/MM/DD/file
+    # We want to write to .../iCloud_Backup/failed_downloads.txt
+    for i, part in enumerate(path_parts):
+        # Find a year-like directory (4 digits starting with 19 or 20)
+        if len(part) == 4 and part.isdigit() and (part.startswith('19') or part.startswith('20')):
+            root_dir = os.sep.join(path_parts[:i])
+            break
+    else:
+        # Fallback: use parent of parent of parent
+        root_dir = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(download_path))))
+    
+    failed_log_path = os.path.join(root_dir, "failed_downloads.txt")
+    timestamp = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    try:
+        with open(failed_log_path, "a") as f:
+            f.write(f"{timestamp}\t{download_path}\t{error_message}\n")
+    except OSError:
+        pass  # Don't fail if we can't write the log
+
+
 def update_mtime(created: datetime.datetime, download_path: str) -> None:
     """Set the modification time of the downloaded file to the photo creation date"""
     if created:
@@ -169,6 +193,7 @@ def download_media(
                     retries,
                     str(ex),
                 )
+                log_failed_download(download_path, f"Connection error after {retries} retries: {ex}")
                 break
             wait_time = (retries + 1) * constants.WAIT_SECONDS
             error_filename = filename_builder(photo)
@@ -202,7 +227,7 @@ def download_media(
                 )
                 time.sleep(wait_time)
 
-        except OSError:
+        except OSError as ex:
             logger.error(
                 "IOError while writing file to %s. "
                 + "You might have run out of disk space, or the file "
@@ -210,6 +235,7 @@ def download_media(
                 + "Skipping this file...",
                 download_path,
             )
+            log_failed_download(download_path, f"OS error: {ex}")
             break
         retries = retries + 1
         if retries >= constants.MAX_RETRIES:
@@ -221,5 +247,6 @@ def download_media(
             "Could not download %s. Please try again later.",
             error_filename,
         )
+        log_failed_download(download_path, f"Max retries ({constants.MAX_RETRIES}) exceeded")
 
     return False

--- a/src/icloudpd/download.py
+++ b/src/icloudpd/download.py
@@ -15,7 +15,7 @@ from tzlocal import get_localzone
 from icloudpd import constants
 from pyicloud_ipd.asset_version import AssetVersion, calculate_version_filename
 from pyicloud_ipd.base import PyiCloudService
-from pyicloud_ipd.exceptions import PyiCloudAPIResponseException
+from pyicloud_ipd.exceptions import PyiCloudAPIResponseException, PyiCloudConnectionErrorException
 from pyicloud_ipd.services.photos import PhotoAsset
 from pyicloud_ipd.version_size import VersionSize
 
@@ -156,6 +156,28 @@ def download_media(
                     size.value,
                 )
                 break
+
+        except PyiCloudConnectionErrorException as ex:
+            # Connection error - retry with backoff, then skip if still failing
+            # Use at least 3 retries for connection errors regardless of MAX_RETRIES setting
+            connection_max_retries = max(3, constants.MAX_RETRIES)
+            if retries >= connection_max_retries:
+                error_filename = filename_builder(photo)
+                logger.warning(
+                    "Connection error downloading %s after %d retries, skipping: %s",
+                    error_filename,
+                    retries,
+                    str(ex),
+                )
+                break
+            wait_time = (retries + 1) * constants.WAIT_SECONDS
+            error_filename = filename_builder(photo)
+            logger.warning(
+                "Connection error downloading %s, retrying after %s seconds...",
+                error_filename,
+                wait_time,
+            )
+            time.sleep(wait_time)
 
         except PyiCloudAPIResponseException as ex:
             if "Invalid global session" in str(ex):


### PR DESCRIPTION
Previously, PyiCloudConnectionErrorException during file downloads would bubble up and abort the entire download process. This was particularly problematic for large libraries where transient connection issues on a single file would stop all progress.

This change:
- Catches PyiCloudConnectionErrorException in download_media()
- Retries up to 3 times with exponential backoff (5s, 10s, 15s)
- Skips the file and continues if retries are exhausted
- Logs warnings instead of errors to indicate the file was skipped

This allows the download to continue even when individual files have connection issues, which can happen due to:
- Transient network problems
- Apple API rate limiting
- Server-side issues with specific files

Problem
When downloading large photo libraries, transient connection errors (PyiCloudConnectionErrorException) during individual file downloads abort the entire download process. This is frustrating for users with thousands of photos, as a single network hiccup stops all progress.

Resuming downloading of /path/to/IMG_XXXX.MOV from NNNNNN
Cannot connect to Apple iCloud service

Root Cause
download_media() catches PyiCloudAPIResponseException but not PyiCloudConnectionErrorException. Connection errors bubble up to core_single_run() which exits.

Solution
Retry with backoff: Up to 3 retries with exponential backoff (5s, 10s, 15s)
Skip and continue: If retries exhausted, log warning and skip the file
Graceful degradation: Download completes for all other files

Testing
Tested with 12,000+ photo library where original code would abort. With this fix, download continues past problematic files.