### PR TITLE
Discover migrated Apple Photos primary zones

### DIFF
--- a/src/icloudpd/base.py
+++ b/src/icloudpd/base.py
@@ -939,6 +939,12 @@ def core_single_run(
                         library_object: PhotoLibrary = icloud.photos.private_libraries[
                             user_config.library
                         ]
+                    elif user_config.library == "PrimarySync" and icloud.photos.zone_id.get(
+                        "zoneName", ""
+                    ).startswith("PrimarySync"):
+                        # Preserve the historical CLI default for accounts whose
+                        # primary zone has been migrated to names such as PrimarySync1.
+                        library_object = icloud.photos
                     elif user_config.library in icloud.photos.shared_libraries:
                         library_object = icloud.photos.shared_libraries[user_config.library]
                     else:

--- a/src/pyicloud_ipd/services/photos.py
+++ b/src/pyicloud_ipd/services/photos.py
@@ -404,12 +404,28 @@ class PhotosService(PhotoLibrary):
 
         self._private_libraries: Dict[str, PhotoLibrary] | None = None
         self._shared_libraries: Dict[str, PhotoLibrary] | None = None
+        self._private_zone_ids: Sequence[Dict[str, Any]] | None = None
 
         self.params.update({"remapEnums": True, "getCurrentSyncToken": True})
 
-        # Initialize as primary library
+        # Apple does not guarantee that the primary library zone is named
+        # exactly "PrimarySync". Discover the active zone first so migrated
+        # accounts using names such as "PrimarySync1" can be initialized.
         service_endpoint = self.get_service_endpoint("private")
-        zone_id = {"zoneName": "PrimarySync"}
+        private_zone_ids = self._fetch_zone_ids("private")
+        self._private_zone_ids = private_zone_ids
+        zone_id = next(
+            (
+                candidate
+                for candidate in private_zone_ids
+                if candidate.get("zoneName", "").startswith("PrimarySync")
+            ),
+            None,
+        )
+        if zone_id is None:
+            raise PyiCloudServiceNotActivatedException(
+                "Apple iCloud Photo Library primary zone was not found", None
+            )
         super().__init__(service_endpoint, self.params, self.session, zone_id, "private")
 
         # TODO: Does syncToken ever change?
@@ -438,27 +454,30 @@ class PhotosService(PhotoLibrary):
         try:
             libraries = {}
             service_endpoint = self.get_service_endpoint(library_type)
-            url = f"{service_endpoint}/zones/list"
-            request = self.session.post(url, data="{}", headers={"Content-type": "text/plain"})
-            response = request.json()
-            for zone in response["zones"]:
-                if not zone.get("deleted"):
-                    zone_name = zone["zoneID"]["zoneName"]
-                    service_endpoint = self.get_service_endpoint(library_type)
-                    libraries[zone_name] = PhotoLibrary(
-                        service_endpoint,
-                        self.params,
-                        self.session,
-                        zone_id=zone["zoneID"],
-                        library_type=library_type,
-                    )
-                    # obj_type='CPLAssetByAssetDateWithoutHiddenOrDeleted',
-                    # list_type="CPLAssetAndMasterByAssetDateWithoutHiddenOrDeleted",
-                    # direction="ASCENDING", query_filter=None,
-                    # zone_id=zone['zoneID'])
+            zone_ids = (
+                self._private_zone_ids
+                if library_type == "private" and self._private_zone_ids is not None
+                else self._fetch_zone_ids(library_type)
+            )
+            for zone_id in zone_ids:
+                zone_name = zone_id["zoneName"]
+                libraries[zone_name] = PhotoLibrary(
+                    service_endpoint,
+                    self.params,
+                    self.session,
+                    zone_id=zone_id,
+                    library_type=library_type,
+                )
         except Exception as e:
             logger.error(f"library exception: {str(e)}")
         return libraries
+
+    def _fetch_zone_ids(self, library_type: str) -> Sequence[Dict[str, Any]]:
+        service_endpoint = self.get_service_endpoint(library_type)
+        url = f"{service_endpoint}/zones/list"
+        request = self.session.post(url, data="{}", headers={"Content-type": "text/plain"})
+        response = request.json()
+        return [zone["zoneID"] for zone in response["zones"] if not zone.get("deleted")]
 
     def get_service_endpoint(self, library_type: str) -> str:
         return f"{self._service_root}/database/1/com.apple.photos.cloud/production/{library_type}"

--- a/tests/test_photos_zone_discovery.py
+++ b/tests/test_photos_zone_discovery.py
@@ -5,7 +5,7 @@ from pyicloud_ipd.exceptions import PyiCloudServiceNotActivatedException
 from pyicloud_ipd.services.photos import PhotosService
 
 
-def response(payload: dict) -> Mock:
+def response(payload: dict[str, object]) -> Mock:
     result = Mock()
     result.json.return_value = payload
     return result

--- a/tests/test_photos_zone_discovery.py
+++ b/tests/test_photos_zone_discovery.py
@@ -1,0 +1,40 @@
+import unittest
+from unittest.mock import Mock
+
+from pyicloud_ipd.exceptions import PyiCloudServiceNotActivatedException
+from pyicloud_ipd.services.photos import PhotosService
+
+
+def response(payload: dict) -> Mock:
+    result = Mock()
+    result.json.return_value = payload
+    return result
+
+
+class PhotosZoneDiscoveryTestCase(unittest.TestCase):
+    def test_uses_discovered_primary_zone(self) -> None:
+        session = Mock()
+        primary_zone = {"zoneName": "PrimarySync1", "ownerRecordName": "owner"}
+        session.post.side_effect = [
+            response({"zones": [{"zoneID": primary_zone}]}),
+            response(
+                {"records": [{"fields": {"state": {"value": "FINISHED"}}}]}
+            ),
+        ]
+
+        photos = PhotosService("https://example.invalid", session, {})
+
+        self.assertEqual(photos.zone_id, primary_zone)
+        self.assertEqual(session.post.call_args_list[0].args[0], (
+            "https://example.invalid/database/1/com.apple.photos.cloud/"
+            "production/private/zones/list"
+        ))
+
+    def test_rejects_accounts_without_primary_zone(self) -> None:
+        session = Mock()
+        session.post.return_value = response(
+            {"zones": [{"zoneID": {"zoneName": "OtherZone"}}]}
+        )
+
+        with self.assertRaises(PyiCloudServiceNotActivatedException):
+            PhotosService("https://example.invalid", session, {})


### PR DESCRIPTION
## Summary

- query Apple Photos private zones before initializing the primary library
- accept active primary zone names such as `PrimarySync1` instead of assuming `PrimarySync`
- preserve the historical `--library PrimarySync` default for migrated accounts
- reuse discovered zone IDs when listing private libraries

## Problem

Some Apple accounts expose their primary Photos zone as `PrimarySync1` or another `PrimarySync*` value. Initializing every account with the hard-coded `PrimarySync` identifier causes Apple to return `ZONE_NOT_FOUND` even though authentication succeeded.

## Validation

- added regression coverage for `PrimarySync1` discovery
- added coverage for the missing-primary-zone error path
- built and started the patched package inside the current boredazfcuk/icloudpd image
- validated against a live account whose primary zone is `PrimarySync1`

The change keeps shared-library discovery unchanged and retains the existing CLI default.