### PR TITLE
Add resumable photo scan checkpoints

### DIFF
--- a/src/pyicloud_ipd/services/photos.py
+++ b/src/pyicloud_ipd/services/photos.py
@@ -1,7 +1,10 @@
 import base64
 import copy
+import hashlib
 import json
 import logging
+import os
+from pathlib import Path
 import re
 import typing
 from datetime import datetime
@@ -487,6 +490,22 @@ class PhotoAlbum:
         self.query_filter = query_filter
         self.page_size = page_size
 
+        self._checkpoint_path: Path | None = None
+        checkpoint_dir = os.environ.get("ICLOUDPD_CHECKPOINT_DIR")
+        if checkpoint_dir:
+            key = json.dumps(
+                [service_endpoint, zone_id, obj_type, list_type, query_filter],
+                sort_keys=True,
+                default=str,
+            ).encode()
+            self._checkpoint_path = Path(checkpoint_dir) / (hashlib.sha256(key).hexdigest() + ".json")
+            try:
+                saved = json.loads(self._checkpoint_path.read_text())
+                self.offset = int(saved["offset"])
+                logger.info("Resuming photo scan from offset %s", self.offset)
+            except (FileNotFoundError, OSError, ValueError, KeyError, json.JSONDecodeError):
+                pass
+
         if zone_id:
             self._zone_id: Dict[str, Any] = zone_id
         else:
@@ -557,6 +576,11 @@ class PhotoAlbum:
 
     def increment_offset(self, value: int) -> None:
         self.offset += value
+        if self._checkpoint_path:
+            self._checkpoint_path.parent.mkdir(parents=True, exist_ok=True)
+            temp_path = self._checkpoint_path.with_suffix(".tmp")
+            temp_path.write_text(json.dumps({"offset": self.offset}))
+            temp_path.replace(self._checkpoint_path)
 
     def _count_query_gen(self, obj_type: str) -> Dict[str, Any]:
         query = {

--- a/tests/test_photo_album_checkpoint.py
+++ b/tests/test_photo_album_checkpoint.py
@@ -1,0 +1,24 @@
+import json
+
+from pyicloud_ipd.services.photos import PhotoAlbum
+
+
+def test_photo_album_checkpoint_restores_and_updates_offset(tmp_path, monkeypatch):
+    monkeypatch.setenv("ICLOUDPD_CHECKPOINT_DIR", str(tmp_path))
+    kwargs = {
+        "params": {},
+        "session": object(),
+        "service_endpoint": "https://example.test/photos",
+        "name": "",
+        "list_type": "CPLAssetAndMasterByAssetDateWithoutHiddenOrDeleted",
+        "obj_type": "CPLAssetByAssetDateWithoutHiddenOrDeleted",
+        "zone_id": {"zoneName": "PrimarySync"},
+    }
+
+    album = PhotoAlbum(**kwargs)
+    album.increment_offset(100)
+    checkpoint = next(tmp_path.glob("*.json"))
+    assert json.loads(checkpoint.read_text()) == {"offset": 100}
+
+    resumed = PhotoAlbum(**kwargs)
+    assert resumed.offset == 100


### PR DESCRIPTION
## What changed

Add an opt-in resumable scan checkpoint for photo albums.

When `ICLOUDPD_CHECKPOINT_DIR` is set, the photo scan stores the processed offset in an atomic JSON checkpoint. A restarted process restores the offset and continues from the saved position.

## Why

The downloader previously restarted photo metadata traversal from the newest assets after a transient iCloud/network failure. This caused expensive repeated scans for large libraries.

## Safety

Checkpointing is disabled by default. The checkpoint key includes the service endpoint, zone, query type, list type, and filter, so different album queries do not share offsets. The offset is advanced only after an asset is yielded, so an interrupted asset may be retried safely.

## Validation

- Added a unit test covering checkpoint creation, persistence, and restoration.
- `python3 -m pytest -q tests/test_photo_album_checkpoint.py` passed in a Python 3 container.
- `python3 -m py_compile src/pyicloud_ipd/services/photos.py` passed.
