### PR TITLE
Skip XMP sidecars when only printing filenames

### DIFF
--- a/src/icloudpd/base.py
+++ b/src/icloudpd/base.py
@@ -727,7 +727,7 @@ def download_builder(
                         download.set_utime(download_path, created_date)
                     logger.info("Downloaded %s", truncated_path)
 
-        if xmp_sidecar:
+        if xmp_sidecar and not only_print_filenames:
             generate_xmp_file(logger, download_path, photo._asset_record, dry_run)
 
     # Also download the live photo if present

--- a/tests/test_issue_1355_xmp_only_print_filenames.py
+++ b/tests/test_issue_1355_xmp_only_print_filenames.py
@@ -1,0 +1,46 @@
+"""Regression test for issue #1355."""
+
+import inspect
+import os
+from unittest import TestCase
+
+import pytest
+
+from tests.helpers import path_from_project_root, run_icloudpd_test
+
+
+class Issue1355XmpOnlyPrintFilenamesTest(TestCase):
+    @pytest.fixture(autouse=True)
+    def inject_fixtures(self) -> None:
+        self.root_path = path_from_project_root(__file__)
+        self.fixtures_path = os.path.join(self.root_path, "fixtures")
+
+    def test_only_print_filenames_skips_xmp_sidecar(self) -> None:
+        base_dir = os.path.join(self.fixtures_path, inspect.stack()[0][3])
+
+        data_dir, result = run_icloudpd_test(
+            self.assertEqual,
+            self.root_path,
+            base_dir,
+            "listing_photos.yml",
+            [],
+            [],
+            [
+                "--username",
+                "jdoe" + "@gmail.com",
+                "--password",
+                "password1",
+                "--recent",
+                "1",
+                "--xmp-sidecar",
+                "--only-print-filenames",
+                "--skip-live-photos",
+                "--no-progress-bar",
+                "--threads-num",
+                "1",
+            ],
+        )
+
+        assert result.exit_code == 0
+        self.assertIn("IMG_7409.JPG", result.output)
+        self.assertEqual([], os.listdir(data_dir))


### PR DESCRIPTION
## Summary

- skip XMP sidecar generation when `--only-print-filenames` is active
- add a regression test that verifies filenames are printed without writing files

Fixes #1355.

## Testing

- `pytest -q tests/test_issue_1355_xmp_only_print_filenames.py` — 1 passed
- `ruff check` and `ruff format --check` on the changed files — passed
- `TZ=UTC pytest -q -k 'not test_folder_structure_de_posix'` — 263 passed, 3 skipped, 1 deselected

The unmodified base branch has the same eight failures under the local local timezone environment: seven timezone/fixture expectation failures and one unavailable `de_DE.UTF-8` locale test. The targeted regression and the UTC suite above pass with this change.
